### PR TITLE
refact: move false to true in plugins and change disable to 'not' so that the user does'nt be confused

### DIFF
--- a/lua/chadrc.lua
+++ b/lua/chadrc.lua
@@ -31,26 +31,26 @@ local M = {
     -- enable and disable plugins (true for disable)
     plugin_status = {
         -- UI
-        nvim_bufferline = false,
-        galaxyline = false,
-        nvim_colorizer = false,
-        dashboard_nvim = false,
-        blankline = false,
-        truezen_nvim = false,
-        better_esc = false,
+        nvim_bufferline = true,
+        galaxyline = true,
+        nvim_colorizer = true,
+        dashboard_nvim = true,
+        blankline = true,
+        truezen_nvim = true,
+        better_esc = true,
         -- lsp stuff
-        lspkind = false,
-        lspsignature = false,
+        lspkind = true,
+        lspsignature = true,
         -- git stuff
-        gitsigns = false,
-        vim_fugitive = false,
+        gitsigns = true,
+        vim_fugitive = true,
         -- misc
-        neoformat = false,
-        vim_matchup = false,
-        autosave_nvim = false,
-        nvim_comment = false,
-        neoscroll_nvim = false,
-        telescope_media = false
+        neoformat = true,
+        vim_matchup = true,
+        autosave_nvim = true,
+        nvim_comment = true,
+        neoscroll_nvim = true,
+        telescope_media = true
     },
     -- make sure you dont use same keys twice
     mappings = {

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -20,7 +20,7 @@ return packer.startup(
 
         use {
             "jdhao/better-escape.vim",
-            disable = plugin_status.better_esc,
+            disable = not plugin_status.better_esc,
             event = "InsertEnter",
             config = function()
                 require "plugins.others".escape()
@@ -29,7 +29,7 @@ return packer.startup(
 
         use {
             "akinsho/nvim-bufferline.lua",
-            disable = plugin_status.nvim_bufferline,
+            disable = not plugin_status.nvim_bufferline,
             after = "nvim-base16.lua",
             config = function()
                 require "plugins.bufferline"
@@ -41,7 +41,7 @@ return packer.startup(
 
         use {
             "glepnir/galaxyline.nvim",
-            disable = plugin_status.galaxyline,
+            disable = not plugin_status.galaxyline,
             after = "nvim-base16.lua",
             config = function()
                 require "plugins.statusline"
@@ -59,7 +59,7 @@ return packer.startup(
 
         use {
             "norcalli/nvim-colorizer.lua",
-            disable = plugin_status.nvim_colorizer,
+            disable = not plugin_status.nvim_colorizer,
             event = "BufRead",
             config = function()
                 require("plugins.others").colorizer()
@@ -90,7 +90,7 @@ return packer.startup(
 
         use {
             "onsails/lspkind-nvim",
-            disable = plugin_status.lspkind,
+            disable = not plugin_status.lspkind,
             event = "BufEnter",
             config = function()
                 require("plugins.others").lspkind()
@@ -99,7 +99,7 @@ return packer.startup(
 
         use {
             "ray-x/lsp_signature.nvim",
-            disable = plugin_status.lspsignature,
+            disable = not plugin_status.lspsignature,
             after = "nvim-lspconfig",
             config = function()
                 require("plugins.others").signature()
@@ -132,7 +132,7 @@ return packer.startup(
 
         use {
             "sbdchd/neoformat",
-            disable = plugin_status.neoformat,
+            disable = not plugin_status.neoformat,
             cmd = "Neoformat",
             setup = function()
                 require "mappings".neoformat()
@@ -178,7 +178,7 @@ return packer.startup(
                 },
                 {
                     "nvim-telescope/telescope-media-files.nvim",
-                    disable = plugin_status.telescope_media,
+                    disable = not plugin_status.telescope_media,
                     setup = function()
                         require "mappings".telescope_media()
                     end
@@ -195,7 +195,7 @@ return packer.startup(
         -- git stuff
         use {
             "lewis6991/gitsigns.nvim",
-            disable = plugin_status.gitsigns,
+            disable = not plugin_status.gitsigns,
             after = "plenary.nvim",
             config = function()
                 require "plugins.gitsigns"
@@ -223,13 +223,13 @@ return packer.startup(
 
         use {
             "andymass/vim-matchup",
-            disable = plugin_status.vim_matchup,
+            disable = not plugin_status.vim_matchup,
             event = "CursorMoved"
         }
 
         use {
             "terrortylor/nvim-comment",
-            disable = plugin_status.nvim_comment,
+            disable = not plugin_status.nvim_comment,
             cmd = "CommentToggle",
             config = function()
                 require("plugins.others").comment()
@@ -241,7 +241,7 @@ return packer.startup(
 
         use {
             "glepnir/dashboard-nvim",
-            disable = plugin_status.dashboard_nvim,
+            disable = not plugin_status.dashboard_nvim,
             cmd = {
                 "Dashboard",
                 "DashboardNewFile",
@@ -257,7 +257,7 @@ return packer.startup(
 
         -- load autosave only if its globally enabled
         use {
-            disable = plugin_status.autosave_nvim,
+            disable = not plugin_status.autosave_nvim,
             "Pocco81/AutoSave.nvim",
             config = function()
                 require "plugins.autosave"
@@ -270,7 +270,7 @@ return packer.startup(
         -- smooth scroll
         use {
             "karb94/neoscroll.nvim",
-            disable = plugin_status.neoscroll_nvim,
+            disable = not plugin_status.neoscroll_nvim,
             event = "WinScrolled",
             config = function()
                 require("plugins.others").neoscroll()
@@ -279,7 +279,7 @@ return packer.startup(
 
         use {
             "Pocco81/TrueZen.nvim",
-            disable = plugin_status.truezen_nvim,
+            disable = not plugin_status.truezen_nvim,
             cmd = {
                 "TZAtaraxis",
                 "TZMinimalist",
@@ -297,7 +297,7 @@ return packer.startup(
 
         use {
             "lukas-reineke/indent-blankline.nvim",
-            disable = plugin_status.blankline,
+            disable = not plugin_status.blankline,
             event = "BufRead",
             setup = function()
                 require("plugins.others").blankline()
@@ -306,7 +306,7 @@ return packer.startup(
 
         use {
             "tpope/vim-fugitive",
-            disable = plugin_status.vim_fugitive,
+            disable = not plugin_status.vim_fugitive,
             cmd = {
                 "Git"
             },


### PR DESCRIPTION
In the following files I have done the following:

- `chadrc.lua`: in the file the plugins were set to false it may confuse the user to that false is disable. So the solution was change it to true
- `pluginList.lua`: In this file I have changed  the following function to not `disable = not plugin_status.galaxyline`. This solves the confusion and doesn't causes and error.

## Testing

The following change was tested by changing the plugin to false and it uninstalled the plugin. Changed the value to true and it installed the plugin. 