### PR TITLE
added relativenumber option & statusline option

### DIFF
--- a/lua/chadrc.lua
+++ b/lua/chadrc.lua
@@ -13,6 +13,7 @@ M.ui = {
    hidden_statusline = {
       -- these are filetypes, not pattern matched
       "NvimTree",
+      -- "terminal", 
    },
 }
 
@@ -27,6 +28,8 @@ M.options = {
    timeoutlen = 400,
    clipboard = "unnamedplus",
    number = true,
+   -- relative numbers in normal mode tool at the bottom of options.lua  
+   relativenumber = false,
    numberwidth = 2,
    expandtab = true,
    shiftwidth = 2,

--- a/lua/default_config.lua
+++ b/lua/default_config.lua
@@ -13,7 +13,7 @@ M.ui = {
    hidden_statusline = {
       -- these are filetypes, not pattern matched
       "NvimTree",
-      "toggleterm",
+      -- "terminal",
    },
 }
 
@@ -28,6 +28,7 @@ M.options = {
    timeoutlen = 400,
    clipboard = "unnamedplus",
    number = true,
+   relativenumber = false,
    numberwidth = 2,
    expandtab = true,
    shiftwidth = 2,

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -27,7 +27,7 @@ opt.fillchars = { eob = " " }
 -- Numbers
 opt.number = options.number
 opt.numberwidth = options.numberwidth
--- opt.relativenumber = true
+opt.relativenumber = options.relativenumber 
 
 -- Indenline
 opt.expandtab = options.expandtab
@@ -67,9 +67,16 @@ for _, plugin in pairs(disabled_built_ins) do
    g["loaded_" .. plugin] = 1
 end
 
--- Don't show status line on certain windows
+-- Use relative & absolute line numbers in 'n' & 'i' modes respectively
+-- vim.cmd[[ au InsertEnter * set norelativenumber ]]
+-- vim.cmd[[ au InsertLeave * set relativenumber ]]
+
+-- Don't show any numbers inside terminals
 vim.cmd [[ au TermOpen term://* setlocal nonumber norelativenumber ]]
-vim.cmd [[let hidden_statusline = luaeval('require("chadrc").ui.hidden_statusline') | autocmd BufEnter,BufWinEnter,WinEnter,CmdwinEnter,TermEnter * nested if index(hidden_statusline, &ft) >= 0 | set laststatus=0 | else | set laststatus=2 | endif]]
+
+-- Don't show status line on certain windows
+vim.cmd [[ au TermOpen term://* setfiletype terminal ]]
+vim.cmd [[ let hidden_statusline = luaeval('require("chadrc").ui.hidden_statusline') | autocmd BufEnter,BufWinEnter,WinEnter,CmdwinEnter,TermEnter * nested if index(hidden_statusline, &ft) >= 0 | set laststatus=0 | else | set laststatus=2 | endif ]]
 
 -- Open a file from its last left off position
 -- vim.cmd [[ au BufReadPost * if expand('%:p') !~# '\m/\.git/' && line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g'\"" | endif ]]


### PR DESCRIPTION
Hi all,

This is a small PR to add:
- the `relativenumber` option to `chadrc.lua` & `default_options.lua`, default is `false`
-- an autocommand to enable hybrid (number + relative) numbers in normal mode, and absolute (number) in insert mode, default is comment out
- imrpoved/fixed the statusline option to work with `NvimTree` (works with terms now too, though not enabled by default)

G