### PR TITLE
chore(telescope): update default path_display config

### DIFF
--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -37,7 +37,10 @@ telescope.setup {
       file_sorter = require("telescope.sorters").get_fuzzy_file,
       file_ignore_patterns = {},
       generic_sorter = require("telescope.sorters").get_generic_fuzzy_sorter,
-      path_display = { "absolute" },
+      path_display = function(opts, path)
+        local tail = require("telescope.utils").path_tail(path)
+        return string.format("%s (%s)", tail, path)
+      end,
       winblend = 0,
       border = {},
       borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },


### PR DESCRIPTION
## Changes
- Update `path_display` default config of telescope. It will display the filename of matched results first, so we can inspect search the results better, especially with long file name.  Related document can be found [here](https://github.com/nvim-telescope/telescope.nvim/blob/master/doc/telescope.txt#L175).

## Screenshot
![Screenshot from 2021-08-19 10-53-37](https://user-images.githubusercontent.com/2762678/130005530-3de6f729-7cc5-43a4-8fc0-f8dcf7b4d9c5.png)
