### PR TITLE
fix Dashboard docs, fix default_config issue

### DIFF
--- a/lua/chadrc.lua
+++ b/lua/chadrc.lua
@@ -20,7 +20,7 @@ M.ui = {
    hidden_statusline = {
       -- these are filetypes, not pattern matched
       "NvimTree",
-      -- "terminal",
+      "terminal",
    },
    statusline_style = "default", -- default, round , slant , block , arrow
 }

--- a/lua/default_config.lua
+++ b/lua/default_config.lua
@@ -20,7 +20,7 @@ M.ui = {
    hidden_statusline = {
       -- these are filetypes, not pattern matched
       "NvimTree",
-      "terminal",
+      -- "terminal",
    },
    statusline_style = "default", -- default, round , slant , block , arrow
 }
@@ -36,6 +36,7 @@ M.options = {
    timeoutlen = 400,
    clipboard = "unnamedplus",
    number = true,
+   -- relative numbers in normal mode tool at the bottom of options.lua
    relativenumber = false,
    numberwidth = 2,
    expandtab = true,

--- a/lua/plugins/dashboard.lua
+++ b/lua/plugins/dashboard.lua
@@ -30,7 +30,7 @@ g.dashboard_custom_section = {
    c = { description = { "  Find Word                 SPC f w" }, command = "Telescope live_grep" },
    d = { description = { "洛 New File                  SPC f n" }, command = "DashboardNewFile" },
    e = { description = { "  Bookmarks                 SPC b m" }, command = "Telescope marks" },
-   f = { description = { "  Load Last Session         SPC s l" }, command = "SessionLoad" },
+   f = { description = { "  Load Last Session         SPC l" }, command = "SessionLoad" },
 }
 
 g.dashboard_custom_footer = {


### PR DESCRIPTION
Hi all,

# Two small fixes:
- The `Dashboard` had an outdated binding (said `<leader> + s + l`, instead of `<leader> + l` for loading a session
- Fix an issue where one cannot enable the statusline in terminals, this is a hack for a proper solution
-- @Akianonymus, think we need to consider how to handle this issue

I checked all the other binds in the `Dashboard`, they seem correct

G