### PR TITLE
Improve statusline config & hotifx close_buffer issue

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -82,6 +82,7 @@ M.close_buffer = function(bufexpr, force)
 
    local buf = vim.fn.bufnr()
    if vim.fn.buflisted(buf) == 0 then -- exit if buffer number is invalid
+      vim.cmd "close"
       return
    end
 


### PR DESCRIPTION
Hi all,

## hotfix close_buffer issue
- the `close_buffer` lua function would exit if the current buffer was unlisted, this prevented closing buffers like `help buffers`
- this has been `hotfixed` IE. revisit this later
- initial testing makes it seem reasonable, but it is not thoroughly tested,
- it's still a big improvement on a breaking change I made (sorry....), so I think this should be pulled in
---

# removed the below commit
## fixing a design issue with statusline
- previously there was no way for the user to enable the statusline on terminals, as it was enabled in `default_config`
- this was fixed by a restructure of the `hide_statusline` table to use boolean flags,
- set an entry like so
  - `terminal = true,`  (filetype = true) true is hide, false is show
---

G