### PR TITLE
Added a command to quickly spin up a working NvChad docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,20 @@ It would be nice if NvChad focuses on existing plugins and config before adding 
 - Make NvChad more and more faster (reduce startup time as low as possible).
 - Add more themes.
 
-# Chad contributors 
+# Try in docker
+
+Try NvChad in a docker container. This will leave your current Neovim configuration untouched. Once you exit Neovim, the image is deleted.
+
+```zsh
+  docker run -w /root -it --rm alpine:edge sh -uelic '
+    apk add git nodejs neovim ripgrep alpine-sdk --update
+    git clone https://github.com/NvChad/NvChad ~/.config/nvim
+    nvim -c "autocmd User PackerComplete quitall" -c "PackerSync"
+    nvim
+    '
+```
+
+# Chad contributors
 
 <a href = "https://github.com/NvChad/NvChad/graphs/contributors">
   <img src = "https://contrib.rocks/image?repo=siduck76/NvChad"/>


### PR DESCRIPTION
Here's a quick demo of how easy it is to quickly get a feel for NvChad without messing with any of your current configuration

[![asciicast](https://asciinema.org/a/RxE9FOZg1p8AgEQkAhPb6tGMj.svg)](https://asciinema.org/a/RxE9FOZg1p8AgEQkAhPb6tGMj)