### PR TITLE
fix contribute link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <span> • </span>
     	<a href="https://nvchad.netlify.app/getting-started/setup">Install</a>
   <span> • </span>
-       	<a href="https://nvchad.netlify.app/docs/Contribute">Contribute</a>
+       	<a href="https://nvchad.netlify.app/contribute">Contribute</a>
   <span> • </span>
 	<a href="https://github.com/siduck76/NvChad#gift_heart-support">Support</a>
   <span> • </span>


### PR DESCRIPTION
Contribute link points to dead link https://nvchad.netlify.app/docs/Contribute. It looks like it should point to https://nvchad.netlify.app/contribute/

Steps to Test
- click Contribute link in this fork/branch's readme: https://github.com/charliestrawn/NvChad/tree/fix-install-link-readme#nvchad