### PR TITLE
commands to load fugitive

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -314,6 +314,11 @@ return packer.startup(function()
       disable = not plugin_status.vim_fugitive,
       cmd = {
          "Git",
+         "Gdiff",
+         "Gdiffsplit",
+         "Gvdiffsplit",
+         "Gwrite",
+         "Gw",
       },
       setup = function()
          require("core.mappings").vim_fugitive()


### PR DESCRIPTION
closes #356 

Adds some fugitive commands make sense to load for. Commands for viewing diffs and for writing. Most commonly used functionality is under `Git` (ie `:Git commit`)