### PR TITLE
Improve commenter config and awareness of contexts

### DIFF
--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -27,7 +27,13 @@ end
 M.comment = function()
    local present, nvim_comment = pcall(require, "nvim_comment")
    if present then
-      nvim_comment.setup()
+      nvim_comment.setup {
+         create_mappings = false,
+         comment_empty = false,
+         hook = function()
+            require("ts_context_commentstring.internal").update_commentstring()
+         end,
+      }
    end
 end
 

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -11,4 +11,8 @@ ts_config.setup {
       enable = true,
       use_languagetree = true,
    },
+   context_commentstring = {
+      enable = require("core.utils").load_config().plugin_status.comment,
+      enable_autocmd = false,
+   },
 }

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -245,6 +245,12 @@ return packer.startup(function()
       end,
    }
 
+   use {
+      "JoosepAlviste/nvim-ts-context-commentstring",
+      disable = not plugin_status.comment,
+      after = "nvim-comment",
+   }
+
    -- file managing , picker etc
    use {
       "kyazdani42/nvim-tree.lua",


### PR DESCRIPTION
I like the comment plugin that was chosen but I found that it was severely lacking in functionality in php (I know), vue, react and other multi language files. I honestly don't know if I could use nvim-comment plugin without this additional integration.

[This plugin](https://github.com/JoosepAlviste/nvim-ts-context-commentstring) sets the `commentstring` option based on the cursor location in the file. The location is checked via treesitter queries. You can see a demo of the context support in the gif at the top of the repo's README.

I simply followed the [integration documentation](https://github.com/JoosepAlviste/nvim-ts-context-commentstring#nvim-comment) in the repo's README.

Thanks so much to all the Chads that have contributed to this awesome config! I understand that this contribution might be rejected due to another plugin being added but the plugin seems light enough and it adds so much more power to the existing commenter that I think will be welcomed by all Chads.