### PR TITLE
Changed mappings to move between windows/terminals with Ctrl+h,j,k,l

### DIFF
--- a/lua/chadrc.lua
+++ b/lua/chadrc.lua
@@ -143,6 +143,11 @@ M.mappings.plugin = {
    bufferline = {
       next_buffer = "<TAB>", -- next buffer
       prev_buffer = "<S-Tab>", -- previous buffer
+      --better window movement
+      moveLeft = "<C-h>",
+      moveRight = "<C-l>",
+      moveUp = "<C-k>",
+      moveDown = "<C-j>",
    },
    chadsheet = {
       default_keys = "<leader>dk",

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -129,6 +129,10 @@ M.bufferline = function()
 
    map("n", m.next_buffer, ":BufferLineCycleNext <CR>")
    map("n", m.prev_buffer, ":BufferLineCyclePrev <CR>")
+   map("n", m.moveLeft, "<C-w>h")
+   map("n", m.moveRight, "<C-w>l")
+   map("n", m.moveUp, "<C-w>k")
+   map("n", m.moveDown, "<C-w>j")
 end
 
 M.chadsheet = function()


### PR DESCRIPTION
I love how these configs are getting better every day!

There was no easy movements between terminals, vimtree nor split opened buffers. With this change, you can move between all of them easily without the mouse by pressing `Ctrl + h` ; `Ctrl + l` ; `Ctrl + j` ; `Ctrl + k` . I thought it should be having it by default. 