### PR TITLE
Improve startup time by speeding up lua module requirements

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -5,14 +5,13 @@ if not present then
 end
 
 local use = packer.use
-require('impatient')
+require "impatient"
 
 return packer.startup(function()
-
-	use {
-		"lewis6991/impatient.nvim",
-		rocks = "mpack",
-	}
+   use {
+      "lewis6991/impatient.nvim",
+      rocks = "mpack",
+   }
 
    local plugin_status = require("core.utils").load_config().plugin_status
 

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -5,8 +5,15 @@ if not present then
 end
 
 local use = packer.use
+require('impatient')
 
 return packer.startup(function()
+
+	use {
+		"lewis6991/impatient.nvim",
+		rocks = "mpack",
+	}
+
    local plugin_status = require("core.utils").load_config().plugin_status
 
    -- this is arranged on the basis of when a plugin starts


### PR DESCRIPTION
#### This is being done using [impatient.nvim](https://github.com/lewis6991/impatient.nvim).

### Who is getting benefited?

+ NvChad modules that are required after the impatient plugin (the first plugin to be loaded) gets loaded.
+ Plugins that are not being lazy loaded (e.g. `NvChad/extensions`, `nvim-lua/plenary.nvim`, user plugins they decide not lazy load, etc...)

### Proof:
+ Here is a[ comparison table](https://github.com/lewis6991/impatient.nvim#performance-example) made by the author of the plugin, where it loads plugins with and without impatient.nvim.
+ Personal test: regarding plugins, I don't lazy load `nvim-cmp`: (measured using Packer.nvim's profiler)

Without impatient.nvim:
![image](https://user-images.githubusercontent.com/58336662/131383695-5d4d9957-28bf-4a65-ac5f-a775ad7ff051.png)

With impatient.nvim:
![image](https://user-images.githubusercontent.com/58336662/131384327-4d97d761-e0b6-4ee4-808c-c9e08f5e1b09.png)
