### PR TITLE
feat: Hook based option overrides

### DIFF
--- a/lua/core/hooks.lua
+++ b/lua/core/hooks.lua
@@ -1,4 +1,4 @@
-local hooks, M = {}, {};
+local hooks, overrides, M = {}, {}, {};
 local allowed_hooks = {
   "install_plugins",
   "setup_mappings",
@@ -34,5 +34,32 @@ M.run = function(name, args)
     hook(args)
   end
 end
+
+M.createOverrides = function(module)
+  local O = {};
+
+  O.get = function(name, default)
+    local current = default;
+    if overrides[module] and overrides[module][name] then
+      for _, override in pairs(overrides[module][name]) do
+        current = override(current)
+      end
+    end
+    return current;
+  end
+
+  return O;
+end
+
+M.override = function(module, name, fn)
+  if overrides[module] == nil then
+    overrides[module] = {};
+  end
+  if overrides[module][name] == nil then
+    overrides[module][name] = {};
+  end
+  table.insert(overrides[module][name], fn)
+end
+
 
 return M;

--- a/lua/custom/init.lua
+++ b/lua/custom/init.lua
@@ -4,6 +4,6 @@
 local hooks = require "core.hooks"
 
 hooks.override("lsp", "publish_diagnostics", function(current)
-  current.virtual_text = false;
-  return current;
+   current.virtual_text = false
+   return current
 end)

--- a/lua/custom/init.lua
+++ b/lua/custom/init.lua
@@ -1,2 +1,9 @@
 -- This is where you custom modules and plugins goes.
 -- See the wiki for a guide on how to extend NvChad
+
+local hooks = require "core.hooks"
+
+hooks.override("lsp", "publish_diagnostics", function(current)
+  current.virtual_text = false;
+  return current;
+end)

--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -1,6 +1,6 @@
 local present1, lspconfig = pcall(require, "lspconfig")
 local present2, lspinstall = pcall(require, "lspinstall")
-local overrides = require("core.hooks").createOverrides("lsp")
+local overrides = require("core.hooks").createOverrides "lsp"
 
 if not (present1 or present2) then
    return
@@ -122,7 +122,7 @@ lspSymbol("Information", "")
 lspSymbol("Hint", "")
 lspSymbol("Warning", "")
 
-local lsp_publish_diagnostics_options = overrides.get('publish_diagnostics', {
+local lsp_publish_diagnostics_options = overrides.get("publish_diagnostics", {
    virtual_text = {
       prefix = "",
       spacing = 0,
@@ -131,7 +131,10 @@ local lsp_publish_diagnostics_options = overrides.get('publish_diagnostics', {
    underline = true,
    update_in_insert = false, -- update diagnostics insert mode
 })
-vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, lsp_publish_diagnostics_options)
+vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
+   vim.lsp.diagnostic.on_publish_diagnostics,
+   lsp_publish_diagnostics_options
+)
 vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
    border = "single",
 })

--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -1,5 +1,6 @@
 local present1, lspconfig = pcall(require, "lspconfig")
 local present2, lspinstall = pcall(require, "lspinstall")
+local overrides = require("core.hooks").createOverrides("lsp")
 
 if not (present1 or present2) then
    return
@@ -121,7 +122,7 @@ lspSymbol("Information", "")
 lspSymbol("Hint", "")
 lspSymbol("Warning", "")
 
-vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
+local lsp_publish_diagnostics_options = overrides.get('publish_diagnostics', {
    virtual_text = {
       prefix = "",
       spacing = 0,
@@ -130,6 +131,7 @@ vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagn
    underline = true,
    update_in_insert = false, -- update diagnostics insert mode
 })
+vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, lsp_publish_diagnostics_options)
 vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
    border = "single",
 })


### PR DESCRIPTION
Hey again.

The issue in #372 does not really get solved by the current hook system, as it only adds the ability to run additional setup during NvChad initialization/commands, not modify the existing stuff.
This is something I was originally wondering if I should add to that original PR but decided against it, as I wasn't sure it is a feature that is generally useful enough, but well given that it could solve some issues, here it is for discussion:

So this introduces hook based overrides.

Of cause `chadrc.lua` should be the main place to configure NvChad, but if all options of all plugins was exposed it would become so extensive that it would be really hard to maintain, so I get having some values be set to something that just works for most people makes sens.

The idea here is that for the rest, it could construct its options using the hook system, using `overrides.get` which would just return the object if no override hooks are registered and everything just-works™. If the user needs to modify any of these "deep" options, it can de done inside `/lua/custom` by registering an override hook, which receives the option, and can then modify it or return something completely different.

This could allow power users or users with very specific requirements access to those deep options, while keeping chadrc to just the options that a lot of people would want to tweak for their need.

I have for illustrative purposes set the specific options from #372 up for override and added an override to `custom/init.lua`, but to be truly useful, all options that power users should be able to override should be wrapped in `overrides.get`

Again, i originally wanted to include this, but decided against it as I don't know if this is the right solution, but could maybe be of use for handling some configuration cases, what do you guys think?