### PR TITLE
Set colors for lsp diagnostics

### DIFF
--- a/lua/plugins/configs/bufferline.lua
+++ b/lua/plugins/configs/bufferline.lua
@@ -64,6 +64,16 @@ bufferline.setup {
          guifg = colors.light_grey,
          guibg = colors.black2,
       },
+      
+      -- for diagnostics = "nvim_lsp"
+      error = {
+         guifg = colors.light_grey,
+         guibg = colors.black2,
+      },
+      error_diagnostic = {
+         guifg = colors.light_grey,
+         guibg = colors.black2
+      },
 
       -- close buttons
       close_button = {


### PR DESCRIPTION
Fixes a small issue with coloring when `diagnostics = "nvim_lsp"` is set to enhance color consistency.

Before, the text background for the unselected tab (evaluator.scm) with a diagnostic does not match the tab background:

![image](https://user-images.githubusercontent.com/6109531/131554318-6311afff-1855-4e2e-8fc6-ebd0d8ee6b91.png)


After, text background matches the tab background:
![image](https://user-images.githubusercontent.com/6109531/131554073-6380f186-a15c-4adf-8a39-1bb072dc2799.png)

There may be more work to make this fully consistent (there are info diagnostics, etc), but this is a start.

