### PR TITLE
fix(plugin): indentline using config instead of setup

### DIFF
--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -43,14 +43,14 @@ M.better_escape = function()
 end
 
 M.blankline = function()
-   vim.g.indentLine_enabled = 1
-   vim.g.indent_blankline_char = "▏"
-
-   vim.g.indent_blankline_filetype_exclude = { "help", "terminal", "dashboard", "packer" }
-   vim.g.indent_blankline_buftype_exclude = { "terminal" }
-
-   vim.g.indent_blankline_show_trailing_blankline_indent = false
-   vim.g.indent_blankline_show_first_indent_level = false
+   require("indent_blankline").setup {
+      indentLine_enabled = 1,
+      char = "▏",
+      indent_blankline_filetype_exclude = { "help", "terminal", "dashboard", "packer" },
+      indent_blankline_buftype_exclude = { "terminal" },
+      indent_blankline_show_trailing_blankline_indent = false,
+      indent_blankline_show_first_indent_level = false,
+   }
 end
 
 M.colorizer = function()


### PR DESCRIPTION
I wanted to set up indent line `show context` and it wasn't working properly.

Your original packer definition of this plugin is using `config`. I think that defining global variables, ie `vim.g.indent_line_do_something` needs to be declared within the packers `setup` function (run before the plugin). 

I went through their docs and saw that they have a setup function instead, and that's usually better than riddling the global scope with variables.