### PR TITLE
fix(indentline): move global vars into the indentline setup call

### DIFF
--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -43,13 +43,10 @@ M.better_escape = function()
 end
 
 M.blankline = function()
-   vim.g.indent_blankline_show_trailing_blankline_indent = false
-   vim.g.indent_blankline_show_first_indent_level = false
-
    require("indent_blankline").setup {
       indentLine_enabled = 1,
       char = "▏",
-      indent_blankline_filetype_exclude = {
+      filetype_exclude = {
          "help",
          "terminal",
          "dashboard",
@@ -58,7 +55,9 @@ M.blankline = function()
          "TelescopePrompt",
          "TelescopeResults",
       },
-      indent_blankline_buftype_exclude = { "terminal" },
+      buftype_exclude = { "terminal" },
+      show_trailing_blankline_indent = false,
+      show_first_indent_level = false,
    }
 end
 


### PR DESCRIPTION
@siduck76 I missed an important part of the docs:

```
Setup
To configure indent-blankline, either run the setup function, or set variables manually. The setup function has a single table as argument, keys of the table match the :help indent-blankline-variables without the indent_blankline_ part.
```

Would you double check that its ok? I think it looks fine to me?

![image](https://user-images.githubusercontent.com/32395961/131739680-ce85ac79-9a57-4db1-8f5d-f2ae9308a6bf.png)
