### PR TITLE
use_lspsaga deprecated, see lsp_signature upstream commit

### DIFF
--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -118,7 +118,6 @@ M.signature = function()
          hint_enable = true,
          hint_prefix = " ",
          hint_scheme = "String",
-         use_lspsaga = false,
          hi_parameter = "Search",
          max_height = 22,
          max_width = 120, -- max_width of signature floating_window, line will be wrapped if exceed max_width


### PR DESCRIPTION
https://github.com/ray-x/lsp_signature.nvim/commit/e5922339e4a48773dded456a244be9130572ddfa

use_lspsaga option deprecated.