### PR TITLE
[Patch] Auto close Nvimtree incase of quitting last existing buffer

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -11,6 +11,9 @@ vim.cmd [[ au TermOpen term://* setlocal nonumber norelativenumber | setfiletype
 -- Don't show status line on certain windows
 vim.cmd [[ autocmd BufEnter,BufWinEnter,FileType,WinEnter * lua require("core.utils").hide_statusline() ]]
 
+--auto close file exploer when quiting incase a single buffer is left
+vim.cmd([[ autocmd BufEnter * if (winnr("$") == 1 && &filetype == 'nvimtree') | q | endif ]])
+
 -- Open a file from its last left off position
 -- vim.cmd [[ au BufReadPost * if expand('%:p') !~# '\m/\.git/' && line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g'\"" | endif ]]
 -- File extension specific tabbing


### PR DESCRIPTION
**PATCH** : This patch aims to close NvimTree (if open) in case the user quits the last existing buffer.

**ASSUMPTION** : It has been assumed that the user would **like to quit** out of nvim as soon as the **last buffer is closed**. If the file explorer is open in this situation it wont close and the user needs to manually exit with `:q!`

**DEMONSTRATION :**

Pre-patch behavior 

https://user-images.githubusercontent.com/65299153/132296060-7193e922-0aa7-4205-90d9-b53a59c9196a.mp4

> Notice when only one buffer is left and it is closed NvimTree is still open after closing it.
The expected behavior would be that NvimTree also closes, instead the user has to use `:q!` to quit out. Repeating this behavior multiple times becomes very annoying.

Patched behavior

https://user-images.githubusercontent.com/65299153/132296546-cfbeb583-f8c3-4ef1-8f54-0d90f429b53d.mp4
> Notice when the single existing buffer is closed NvimTree also  closes simultaneously quitting out of neovim