### PR TITLE
Update feline config to new format

### DIFF
--- a/lua/plugins/configs/statusline.lua
+++ b/lua/plugins/configs/statusline.lua
@@ -47,12 +47,19 @@ local statusline_style = icon_styles[user_statusline_style]
 
 -- Initialize the components table
 local components = {
-   left = { active = {}, inactive = {} },
-   mid = { active = {}, inactive = {} },
-   right = { active = {}, inactive = {} },
+    active = {},
+    inactive = {}
 }
 
-components.left.active[1] = {
+-- Initialize left, mid and right
+table.insert(components.active, {})
+table.insert(components.active, {})
+table.insert(components.active, {})
+table.insert(components.inactive, {})
+table.insert(components.inactive, {})
+table.insert(components.inactive, {})
+
+components.active[1][1] = {
    provider = statusline_style.main_icon,
 
    hl = {
@@ -66,7 +73,7 @@ components.left.active[1] = {
    } },
 }
 
-components.left.active[2] = {
+components.active[1][2] = {
    provider = statusline_style.right,
 
    hl = {
@@ -75,7 +82,7 @@ components.left.active[2] = {
    },
 }
 
-components.left.active[3] = {
+components.active[1][3] = {
    provider = function()
       local filename = vim.fn.expand "%:t"
       local extension = vim.fn.expand "%:e"
@@ -94,7 +101,7 @@ components.left.active[3] = {
    right_sep = { str = statusline_style.right, hl = { fg = colors.lightbg, bg = colors.lightbg2 } },
 }
 
-components.left.active[4] = {
+components.active[1][4] = {
    provider = function()
       local dir_name = vim.fn.fnamemodify(vim.fn.getcwd(), ":t")
       return "  " .. dir_name .. " "
@@ -110,7 +117,7 @@ components.left.active[4] = {
    } },
 }
 
-components.left.active[5] = {
+components.active[1][5] = {
    provider = "git_diff_added",
    hl = {
       fg = colors.grey_fg2,
@@ -119,7 +126,7 @@ components.left.active[5] = {
    icon = " ",
 }
 -- diffModfified
-components.left.active[6] = {
+components.active[1][6] = {
    provider = "git_diff_changed",
    hl = {
       fg = colors.grey_fg2,
@@ -128,7 +135,7 @@ components.left.active[6] = {
    icon = "   ",
 }
 -- diffRemove
-components.left.active[7] = {
+components.active[1][7] = {
    provider = "git_diff_removed",
    hl = {
       fg = colors.grey_fg2,
@@ -137,7 +144,7 @@ components.left.active[7] = {
    icon = "  ",
 }
 
-components.left.active[8] = {
+components.active[1][8] = {
    provider = "diagnostic_errors",
    enabled = function()
       return lsp.diagnostics_exist "Error"
@@ -146,7 +153,7 @@ components.left.active[8] = {
    icon = "  ",
 }
 
-components.left.active[9] = {
+components.active[1][9] = {
    provider = "diagnostic_warnings",
    enabled = function()
       return lsp.diagnostics_exist "Warning"
@@ -155,7 +162,7 @@ components.left.active[9] = {
    icon = "  ",
 }
 
-components.left.active[10] = {
+components.active[1][10] = {
    provider = "diagnostic_hints",
    enabled = function()
       return lsp.diagnostics_exist "Hint"
@@ -164,7 +171,7 @@ components.left.active[10] = {
    icon = "  ",
 }
 
-components.left.active[11] = {
+components.active[1][11] = {
    provider = "diagnostic_info",
    enabled = function()
       return lsp.diagnostics_exist "Information"
@@ -173,7 +180,7 @@ components.left.active[11] = {
    icon = "  ",
 }
 
-components.mid.active[1] = {
+components.active[2][1] = {
    provider = function()
       local Lsp = vim.lsp.util.get_progress_messages()[1]
       if Lsp then
@@ -206,7 +213,7 @@ components.mid.active[1] = {
    hl = { fg = colors.green },
 }
 
-components.right.active[1] = {
+components.active[3][1] = {
    provider = function()
       if next(vim.lsp.buf_get_clients()) ~= nil then
          return "  LSP"
@@ -217,7 +224,7 @@ components.right.active[1] = {
    hl = { fg = colors.grey_fg2, bg = colors.statusline_bg },
 }
 
-components.right.active[2] = {
+components.active[3][2] = {
    -- taken from: https://github.com/hoob3rt/lualine.nvim/blob/master/lua/lualine/components/branch.lua
    provider = function()
       local git_branch = ""
@@ -275,7 +282,7 @@ components.right.active[2] = {
    },
 }
 
-components.right.active[3] = {
+components.active[3][3] = {
    provider = " " .. statusline_style.left,
    hl = {
       fg = colors.one_bg2,
@@ -313,7 +320,7 @@ local chad_mode_hl = function()
    }
 end
 
-components.right.active[4] = {
+components.active[3][4] = {
    provider = statusline_style.left,
    hl = function()
       return {
@@ -323,7 +330,7 @@ components.right.active[4] = {
    end,
 }
 
-components.right.active[5] = {
+components.active[3][5] = {
    provider = statusline_style.vi_mode_icon,
    hl = function()
       return {
@@ -333,14 +340,14 @@ components.right.active[5] = {
    end,
 }
 
-components.right.active[6] = {
+components.active[3][6] = {
    provider = function()
       return " " .. mode_colors[vim.fn.mode()][1] .. " "
    end,
    hl = chad_mode_hl,
 }
 
-components.right.active[7] = {
+components.active[3][7] = {
    provider = statusline_style.left,
    hl = {
       fg = colors.grey,
@@ -348,7 +355,7 @@ components.right.active[7] = {
    },
 }
 
-components.right.active[8] = {
+components.active[3][8] = {
    provider = statusline_style.left,
    hl = {
       fg = colors.green,
@@ -356,7 +363,7 @@ components.right.active[8] = {
    },
 }
 
-components.right.active[9] = {
+components.active[3][9] = {
    provider = statusline_style.position_icon,
    hl = {
       fg = colors.black,
@@ -364,7 +371,7 @@ components.right.active[9] = {
    },
 }
 
-components.right.active[10] = {
+components.active[3][10] = {
    provider = function()
       local current_line = vim.fn.line "."
       local total_line = vim.fn.line "$"


### PR DESCRIPTION
Feline changed their config format and deprecated the old one (see https://github.com/famiu/feline.nvim/commit/8c809b2416fa6773719f3c391eb7b124d67c866e). This PR updates NvChad's config, solves issue #435 