### PR TITLE
feat: Move treesitter branch to compat-0.5

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -82,6 +82,7 @@ return packer.startup(function()
 
    use {
       "nvim-treesitter/nvim-treesitter",
+      branch = "0.5-compat",
       event = "BufRead",
       config = function()
          require "plugins.configs.treesitter"


### PR DESCRIPTION
If you want to use this plugin with Neovim 0.5, please use the 0.5-compat branch. Be aware though that most improvements will require neovim nightly.
https://github.com/nvim-treesitter/nvim-treesitter