### PR TITLE
Offset configuration and runtimepath install

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,43 @@
+local cmd = vim.cmd
+local env = vim.env
+local fn = vim.fn
+local g = vim.g
+local loop = vim.loop
+local opt = vim.opt
+
+-- The default 'project_name' is taken from the parent directory name of
+-- this configuration repo.
+local config_lua_name = loop.fs_realpath(
+    debug.getinfo(1, 'S').source:match("^@?(.*)$")
+  )
+local config_lua_dir = config_lua_name:match("^(.*)/[^/]*$")
+local config_lua_parent = config_lua_dir:match("^.*/([^/]+)$")
+if config_lua_parent == nil then
+  -- This shouldn't be the case but just in case
+  config_lua_parent = "nvim"
+end
+-- Exporting the environment variable $PROJECT_NAME can force to set 'project_name'
+local project_name = fn.exists(env.PROJECT_NAME) and env.PROJECT_NAME or config_lua_parent
+
+local home_dir = loop.os_homedir()
+local xdg_config_home = fn.exists(env.XDG_CONFIG_HOME) and env.XDG_CONFIG_HOME or home_dir .. '/.config'
+local xdg_data_home = fn.exists(env.XDG_DATA_HOME) and env.XDG_DATA_HOME or home_dir .. '/.local/share'
+
+-- Export project specific paths as a global varibale
+g.project_config = xdg_config_home .. '/' .. project_name
+g.project_site = xdg_data_home .. '/' .. project_name .. '/site'
+
+-- update runtimepath with project specific ones
+opt.rtp:remove(xdg_config_home .. "/nvim")
+opt.rtp:remove(xdg_config_home .. "/nvim/after")
+opt.rtp:prepend(g.project_config)
+opt.rtp:append(g.project_config .. "/after")
+opt.rtp:remove(xdg_data_home .. "/nvim/site")
+opt.rtp:remove(xdg_data_home .. "/nvim/site/after")
+opt.rtp:prepend(g.project_site)
+opt.rtp:append(g.project_site .. "/after")
+cmd [[let &packpath = &runtimepath]]
+
 local init_modules = {
    "core",
 }

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -154,7 +154,7 @@ M.load_config = function(reload)
 
    local default_config = "default_config"
    local config_name = vim.g.nvchad_user_config or "chadrc"
-   local config_file = vim.fn.stdpath "config" .. "/lua/" .. config_name .. ".lua"
+   local config_file = vim.g.project_config .. "/lua/" .. config_name .. ".lua"
 
    -- unload the modules if force reload
    if reload then

--- a/lua/plugins/packerInit.lua
+++ b/lua/plugins/packerInit.lua
@@ -5,7 +5,7 @@ cmd "packadd packer.nvim"
 local present, packer = pcall(require, "packer")
 
 if not present then
-   local packer_path = vim.fn.stdpath "data" .. "/site/pack/packer/opt/packer.nvim"
+   local packer_path = vim.g.project_site .. "/pack/packer/opt/packer.nvim"
 
    print "Cloning packer.."
    -- remove the dir before cloning
@@ -30,6 +30,8 @@ if not present then
 end
 
 packer.init {
+   package_root = vim.g.project_site .. '/pack',
+   compile_path = vim.g.project_config .. '/plugin/packer_compiled.lua',
    display = {
       open_fn = function()
          return require("packer.util").float { border = "single" }

--- a/nv
+++ b/nv
@@ -1,0 +1,19 @@
+#!/bin/sh -e
+
+# Helper script to start nvim with offset configuration by placing a
+# copied script in your ~/.local/bin/.
+
+# If you installed NvChad to ~/.config/nvim_NvChad, you can use this
+# script as is.
+
+# Otherwise, please edit to match your situation.
+
+HOME=~
+PROJECT_BIN="nvim"           # binary executable name for nvim
+PROJECT_NAME="nvim-NvChad"   # configuration data location (parent only)
+
+# If you put your configuration data elsewhere other than the normal
+# ~/.config, rewrite this to set it with the full path.
+GIT_CLONE_DIR=${XDG_CONFIG_HOME:-$HOME/.config/$PROJECT_NAME}
+
+exec "${PROJECT_BIN}" -u "${GIT_CLONE_DIR}/init.lua" "$@"


### PR DESCRIPTION
Normal installation of NvChad requires you to clone this repo to
~/.config/nvim.  This patch doesn't affect it.

If you want to switch between different configurations, you need to
deploy some kind of virtualization techniques (chroot, docker, ...).
This is not really worth it.

As I saw https://github.com/LunarVim/LunarVim demonstrating to install
its configuration and set its runtimepath offset from their standard
location to solve *co-existance* problem, I decided to do the same for
my personal somewhat old-style configuration in lua.  Unlike LunarVim, I
tried to avoid hardcoding offset path.

Since NvChad seems seems good baseline for my next nvim lua setup, I
ported my offset configuration and runtimepath install.

This patch allows to install NvChad non-invasively.

* Do `git clone` this configuration repo to ~/.config/${PROJECT_NAME}
  Please chose ${PROJECT_NAME} to be `nvim-NvChad` (no `nvim`) to meke
  this interesting  and easy.

  $ git clone https://github.com/osamuaoki/NvChad ~/.config/nvim-NvChad
  $ cd ~/.config/nvim-NvChad
  $ ./nv -c "autocmd User PackerComplete quitall" -c "PackerSync

* Copy `nv` file to a directory in early $PATH such as $HOME/.local/bin
  or $HOME/bin.  `nv` will start NvChad configured nvim.

  $ cp nv ~/.local/bin/

* (Optional)Rename or copy the `nv` to names such as `vi` or `vim` to
  start this as default for those names.  (Remove them to get your old
  ways)

Signed-off-by: Osamu Aoki <osamu@debian.org>