### PR TITLE
ignore node_module folder in telescope

### DIFF
--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -35,7 +35,7 @@ telescope.setup {
          preview_cutoff = 120,
       },
       file_sorter = require("telescope.sorters").get_fuzzy_file,
-      file_ignore_patterns = {},
+      file_ignore_patterns = {"node_modules"},
       generic_sorter = require("telescope.sorters").get_generic_fuzzy_sorter,
       path_display = { "absolute" },
       winblend = 0,


### PR DESCRIPTION
Just a minor tweak to telescope config

1. Added node_modules to file_ignore_patterns

It's just annoying to see the node_modules folder in telescope, and it doesn't always match correctly when there are too many files.