### PR TITLE
fix: Replace Website Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <h1 align="center">NvChad</h1>
 
 <div align="center">
-	<a href="https://nvchad.netlify.app/">Home</a>
+	<a href="https://nvchad.github.io/">Home</a>
   <span> • </span>
-    	<a href="https://nvchad.netlify.app/getting-started/setup">Install</a>
+    	<a href="https://nvchad.github.io/getting-started/setup">Install</a>
   <span> • </span>
-       	<a href="https://nvchad.netlify.app/contribute">Contribute</a>
+       	<a href="https://nvchad.github.io/contribute">Contribute</a>
   <span> • </span>
 	<a href="https://github.com/siduck76/NvChad#gift_heart-support">Support</a>
   <span> • </span>


### PR DESCRIPTION
With the new docs I changed the links in the Readme. The link in the about section of the repo also needs to be updated, but its not something I can do.