### PR TITLE
fix: ignore unwanted files in custom dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 plugin
+lua/custom/*
+!lua/custom/example_init.lua
+!lua/custom/example_chadrc.lua


### PR DESCRIPTION
- since it's pointless to track user specific files, added the custom dir to the ignore list except for the example files.