### PR TITLE
Moved the setting into setup for Nvimtree

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -11,7 +11,6 @@ local g = vim.g
 vim.o.termguicolors = true
 
 g.nvim_tree_add_trailing = 0 -- append a trailing slash to folder names
-g.nvim_tree_allow_resize = 1
 g.nvim_tree_git_hl = git_status
 g.nvim_tree_gitignore = git_status
 g.nvim_tree_hide_dotfiles = 0
@@ -20,9 +19,7 @@ g.nvim_tree_indent_markers = 1
 g.nvim_tree_ignore = { ".git", "node_modules", ".cache" }
 g.nvim_tree_quit_on_open = 0 -- closes tree when file's opened
 g.nvim_tree_root_folder_modifier = table.concat { ":t:gs?$?/..", string.rep(" ", 1000), "?:gs?^??" }
-g.nvim_tree_side = "left"
-g.nvim_tree_width = 25
-
+-- 
 g.nvim_tree_show_icons = {
    folders = 1,
    -- folder_arrows= 1
@@ -55,39 +52,7 @@ g.nvim_tree_icons = {
    },
 }
 
-g.nvim_tree_bindings = {
-   { key = { "<CR>", "o", "<2-LeftMouse>" }, cb = tree_cb "edit" },
-   { key = { "<2-RightMouse>", "<C-]>" }, cb = tree_cb "cd" },
-   { key = "<C-v>", cb = tree_cb "vsplit" },
-   { key = "<C-x>", cb = tree_cb "split" },
-   { key = "<C-t>", cb = tree_cb "tabnew" },
-   { key = "<", cb = tree_cb "prev_sibling" },
-   { key = ">", cb = tree_cb "next_sibling" },
-   { key = "P", cb = tree_cb "parent_node" },
-   { key = "<BS>", cb = tree_cb "close_node" },
-   { key = "<S-CR>", cb = tree_cb "close_node" },
-   { key = "<Tab>", cb = tree_cb "preview" },
-   { key = "K", cb = tree_cb "first_sibling" },
-   { key = "J", cb = tree_cb "last_sibling" },
-   { key = "I", cb = tree_cb "toggle_ignored" },
-   { key = "H", cb = tree_cb "toggle_dotfiles" },
-   { key = "R", cb = tree_cb "refresh" },
-   { key = "a", cb = tree_cb "create" },
-   { key = "d", cb = tree_cb "remove" },
-   { key = "r", cb = tree_cb "rename" },
-   { key = "<C->", cb = tree_cb "full_rename" },
-   { key = "x", cb = tree_cb "cut" },
-   { key = "c", cb = tree_cb "copy" },
-   { key = "p", cb = tree_cb "paste" },
-   { key = "y", cb = tree_cb "copy_name" },
-   { key = "Y", cb = tree_cb "copy_path" },
-   { key = "gy", cb = tree_cb "copy_absolute_path" },
-   { key = "[c", cb = tree_cb "prev_git_item" },
-   { key = "}c", cb = tree_cb "next_git_item" },
-   { key = "-", cb = tree_cb "dir_up" },
-   { key = "q", cb = tree_cb "close" },
-   { key = "g?", cb = tree_cb "toggle_help" },
-}
+
 
 require("nvim-tree").setup {
    lsp_diagnostics = false,
@@ -102,4 +67,48 @@ require("nvim-tree").setup {
       enable = true,
       update_cwd = true,
    },
+  view = {
+    allow_resize = true, 
+    side = 'left',
+    width = '25',
+    mappings = {
+      list = {  
+        { key = { "<CR>", "o", "<2-LeftMouse>" }, cb = tree_cb "edit" },
+        { key = { "<2-RightMouse>", "<C-]>" }, cb = tree_cb "cd" },
+        { key = "<C-v>", cb = tree_cb "vsplit" },
+        { key = "<C-x>", cb = tree_cb "split" },
+        { key = "<C-t>", cb = tree_cb "tabnew" },
+        { key = "<", cb = tree_cb "prev_sibling" },
+        { key = ">", cb = tree_cb "next_sibling" },
+        { key = "P", cb = tree_cb "parent_node" },
+        { key = "<BS>", cb = tree_cb "close_node" },
+        { key = "<S-CR>", cb = tree_cb "close_node" },
+        { key = "<Tab>", cb = tree_cb "preview" },
+        { key = "K", cb = tree_cb "first_sibling" },
+        { key = "J", cb = tree_cb "last_sibling" },
+        { key = "I", cb = tree_cb "toggle_ignored" },
+        { key = "H", cb = tree_cb "toggle_dotfiles" },
+        { key = "R", cb = tree_cb "refresh" },
+        { key = "a", cb = tree_cb "create" },
+        { key = "d", cb = tree_cb "remove" },
+        { key = "r", cb = tree_cb "rename" },
+        { key = "<C->", cb = tree_cb "full_rename" },
+        { key = "x", cb = tree_cb "cut" },
+        { key = "c", cb = tree_cb "copy" },
+        { key = "p", cb = tree_cb "paste" },
+        { key = "y", cb = tree_cb "copy_name" },
+        { key = "Y", cb = tree_cb "copy_path" },
+        { key = "gy", cb = tree_cb "copy_absolute_path" },
+        { key = "[c", cb = tree_cb "prev_git_item" },
+        { key = "}c", cb = tree_cb "next_git_item" },
+        { key = "-", cb = tree_cb "dir_up" },
+        { key = "q", cb = tree_cb "close" },
+        { key = "g?", cb = tree_cb "toggle_help" },
+      },
+    },
+  },
 }
+
+
+
+

--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -68,7 +68,7 @@ require("nvim-tree").setup {
    view = {
       allow_resize = true,
       side = "left",
-      width = "25",
+      width = 25,
       mappings = {
          list = {
             { key = { "<CR>", "o", "<2-LeftMouse>" }, cb = tree_cb "edit" },

--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -19,7 +19,7 @@ g.nvim_tree_indent_markers = 1
 g.nvim_tree_ignore = { ".git", "node_modules", ".cache" }
 g.nvim_tree_quit_on_open = 0 -- closes tree when file's opened
 g.nvim_tree_root_folder_modifier = table.concat { ":t:gs?$?/..", string.rep(" ", 1000), "?:gs?^??" }
--- 
+--
 g.nvim_tree_show_icons = {
    folders = 1,
    -- folder_arrows= 1
@@ -52,8 +52,6 @@ g.nvim_tree_icons = {
    },
 }
 
-
-
 require("nvim-tree").setup {
    lsp_diagnostics = false,
    disable_netrw = true,
@@ -67,48 +65,44 @@ require("nvim-tree").setup {
       enable = true,
       update_cwd = true,
    },
-  view = {
-    allow_resize = true, 
-    side = 'left',
-    width = '25',
-    mappings = {
-      list = {  
-        { key = { "<CR>", "o", "<2-LeftMouse>" }, cb = tree_cb "edit" },
-        { key = { "<2-RightMouse>", "<C-]>" }, cb = tree_cb "cd" },
-        { key = "<C-v>", cb = tree_cb "vsplit" },
-        { key = "<C-x>", cb = tree_cb "split" },
-        { key = "<C-t>", cb = tree_cb "tabnew" },
-        { key = "<", cb = tree_cb "prev_sibling" },
-        { key = ">", cb = tree_cb "next_sibling" },
-        { key = "P", cb = tree_cb "parent_node" },
-        { key = "<BS>", cb = tree_cb "close_node" },
-        { key = "<S-CR>", cb = tree_cb "close_node" },
-        { key = "<Tab>", cb = tree_cb "preview" },
-        { key = "K", cb = tree_cb "first_sibling" },
-        { key = "J", cb = tree_cb "last_sibling" },
-        { key = "I", cb = tree_cb "toggle_ignored" },
-        { key = "H", cb = tree_cb "toggle_dotfiles" },
-        { key = "R", cb = tree_cb "refresh" },
-        { key = "a", cb = tree_cb "create" },
-        { key = "d", cb = tree_cb "remove" },
-        { key = "r", cb = tree_cb "rename" },
-        { key = "<C->", cb = tree_cb "full_rename" },
-        { key = "x", cb = tree_cb "cut" },
-        { key = "c", cb = tree_cb "copy" },
-        { key = "p", cb = tree_cb "paste" },
-        { key = "y", cb = tree_cb "copy_name" },
-        { key = "Y", cb = tree_cb "copy_path" },
-        { key = "gy", cb = tree_cb "copy_absolute_path" },
-        { key = "[c", cb = tree_cb "prev_git_item" },
-        { key = "}c", cb = tree_cb "next_git_item" },
-        { key = "-", cb = tree_cb "dir_up" },
-        { key = "q", cb = tree_cb "close" },
-        { key = "g?", cb = tree_cb "toggle_help" },
+   view = {
+      allow_resize = true,
+      side = "left",
+      width = "25",
+      mappings = {
+         list = {
+            { key = { "<CR>", "o", "<2-LeftMouse>" }, cb = tree_cb "edit" },
+            { key = { "<2-RightMouse>", "<C-]>" }, cb = tree_cb "cd" },
+            { key = "<C-v>", cb = tree_cb "vsplit" },
+            { key = "<C-x>", cb = tree_cb "split" },
+            { key = "<C-t>", cb = tree_cb "tabnew" },
+            { key = "<", cb = tree_cb "prev_sibling" },
+            { key = ">", cb = tree_cb "next_sibling" },
+            { key = "P", cb = tree_cb "parent_node" },
+            { key = "<BS>", cb = tree_cb "close_node" },
+            { key = "<S-CR>", cb = tree_cb "close_node" },
+            { key = "<Tab>", cb = tree_cb "preview" },
+            { key = "K", cb = tree_cb "first_sibling" },
+            { key = "J", cb = tree_cb "last_sibling" },
+            { key = "I", cb = tree_cb "toggle_ignored" },
+            { key = "H", cb = tree_cb "toggle_dotfiles" },
+            { key = "R", cb = tree_cb "refresh" },
+            { key = "a", cb = tree_cb "create" },
+            { key = "d", cb = tree_cb "remove" },
+            { key = "r", cb = tree_cb "rename" },
+            { key = "<C->", cb = tree_cb "full_rename" },
+            { key = "x", cb = tree_cb "cut" },
+            { key = "c", cb = tree_cb "copy" },
+            { key = "p", cb = tree_cb "paste" },
+            { key = "y", cb = tree_cb "copy_name" },
+            { key = "Y", cb = tree_cb "copy_path" },
+            { key = "gy", cb = tree_cb "copy_absolute_path" },
+            { key = "[c", cb = tree_cb "prev_git_item" },
+            { key = "}c", cb = tree_cb "next_git_item" },
+            { key = "-", cb = tree_cb "dir_up" },
+            { key = "q", cb = tree_cb "close" },
+            { key = "g?", cb = tree_cb "toggle_help" },
+         },
       },
-    },
-  },
+   },
 }
-
-
-
-


### PR DESCRIPTION
Options are currently being migrated into the setup function, you need to run require'nvim-tree'.setup() in your personal configurations. Setup should be run in a lua file or in a lua heredoc (:help lua-heredoc) if using in a vim file. Note that options under the g: command should be set BEFORE running the setup function.

I've moved the ones that have been migrated 