### PR TITLE
fix: `default_config` var `plugin` -> `plugins` instead

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -2,7 +2,7 @@
 -- use custom/chadrc.lua instead
 
 local M = {}
-M.options, M.ui, M.mappings, M.plugin = {}, {}, {}, {}
+M.options, M.ui, M.mappings, M.plugins = {}, {}, {}, {}
 
 -- non plugin normal, available without any plugins
 M.options = {
@@ -99,7 +99,7 @@ M.plugins = {
          style = "default",
       },
       autosave = false, -- autosave on changed text or insert mode leave
-      -- timeout to be used for using escape with a key combination, see mappings.plugin.better_escape
+      -- timeout to be used for using escape with a key combination, see mappings.plugins.better_escape
       esc_insertmode_timeout = 300,
    },
    default_plugin_config_replace = {},

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -147,7 +147,7 @@ M.load_config = function(reload)
 
    -- these are the table value which will be always prioritiezed to take user config value
    local to_replace = {
-      "['mappings']['plugin']['esc_insertmode']",
+      "['mappings']['plugins']['esc_insertmode']",
       "['mappings']['terminal']['esc_termmode']",
       "['mappings']['terminal']['esc_hide_termmode']",
    }
@@ -243,7 +243,7 @@ end
 -- 1st arg - base table
 -- 2nd arg - table to merge
 -- 3rg arg - list of nodes as a table, if the node is found replace the from table2 to result, rather than adding the value
--- e.g: merge_table(t1, t2, { ['plugin']['truezen']['mappings'] })
+-- e.g: merge_table(t1, t2, { ['mappings']['plugins']['bufferline'] })
 M.merge_table = function(into, from, nodes_to_replace)
    -- make sure both are table
    if type(into) ~= "table" or type(from) ~= "table" then
@@ -272,7 +272,7 @@ end]]
        end
 
       for _, node in ipairs(nodes_to_replace) do
-         -- pcall() is a poor workaround for if "['mappings']['plugin']['esc_insertmode']" 'plugin' sub-table does not exist
+         -- pcall() is a poor workaround for if "['mappings']['plugins']['esc_insertmode']" 'plugins' sub-table does not exist
          local ok, result = pcall(replace_fn, node)
          if ok then
             -- if the node is found then replace


### PR DESCRIPTION
Ahhh, sorry

I think I must've missed this single var rename inside of `default_config`,

`plugin` when it should be `plugins`.

The rest of the changes are all pretty much comments.

---

This should not impact any users at all,

and this will only fix 1 bug with `"['mappings']['plugins']['esc_insertmode']",`
as it was referencing `plugin` not `plugins`

G