### PR TITLE
chore: Clean init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,5 @@
 local ok, err = pcall(require, "core")
+
 if not ok then
    error("Error loading " .. module .. "\n\n" .. err)
 end

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
 local ok, err = pcall(require, "core")
 if not ok then
-	error("Error loading " .. module .. "\n\n" .. err)
+   error("Error loading " .. module .. "\n\n" .. err)
 end

--- a/init.lua
+++ b/init.lua
@@ -1,10 +1,4 @@
-local init_modules = {
-   "core",
-}
-
-for _, module in ipairs(init_modules) do
-   local ok, err = pcall(require, module)
-   if not ok then
-      error("Error loading " .. module .. "\n\n" .. err)
-   end
+local ok, err = pcall(require, "core")
+if not ok then
+	error("Error loading " .. module .. "\n\n" .. err)
 end


### PR DESCRIPTION
Why do we have a table to require a single module. We had this when we had plugins, colors etc. 
But we only have one module now. So why bother a list and looping through for a single module ?