### PR TITLE
add config option to disable nvimtree

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -57,7 +57,7 @@ M.ui = {
 -- these are plugin related options
 M.plugins = {
    -- enable and disable plugins (false for disable)
-      status = {
+   status = {
       autosave = false, -- to autosave files
       blankline = true, -- show code scope with symbols
       bufferline = true, -- list open buffers up the top, easy switching too
@@ -73,6 +73,7 @@ M.plugins = {
       truezen = false, -- distraction free & minimalist UI mode
       vim_matchup = true, -- % operator enhancements
       cmp = true,
+      nvimtree = true,
    },
    options = {
       lspconfig = {

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -252,6 +252,7 @@ return packer.startup(function()
    -- file managing , picker etc
    use {
       "kyazdani42/nvim-tree.lua",
+      disable = not status.nvimtree,
       cmd = { "NvimTreeToggle", "NvimTreeFocus" },
       config = override_req("nvim_tree", "plugins.configs.nvimtree"),
       setup = function()


### PR DESCRIPTION
I don't use file browsers in vim (just fuzzy finders), so I was looking to disable nvimtree. I was surprised that the config didn't support disabling it, like you can with other plugins. I assume this was an oversight, but correct me if I'm wrong and it's required somehow.