### PR TITLE
added highlight override support

### DIFF
--- a/lua/colors/highlights.lua
+++ b/lua/colors/highlights.lua
@@ -1,3 +1,4 @@
+local override = require("core.utils").load_config().options.hl_override
 local cmd = vim.cmd
 
 local colors = require("colors").get()
@@ -155,3 +156,7 @@ fg("TelescopeBorder", one_bg)
 fg_bg("TelescopePreviewTitle", green, one_bg)
 fg_bg("TelescopePromptTitle", blue, one_bg)
 fg_bg("TelescopeResultsTitle", red, one_bg)
+
+if override then
+   require(override)
+end

--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -38,6 +38,7 @@ M.options = {
       update_url = "https://github.com/NvChad/NvChad",
       update_branch = "main",
    },
+  hl_override = false, --set this equal to "custom.some.file" (which contains highlights) in custom.chadrc to modify hl groups set by the colorscheme
 }
 
 -- ui configs


### PR DESCRIPTION
I use classic vim-tabs, but highlights do not function no matter what I do. Something like vim.cmd[[hi TabLineFill "#000000"]] works flawlessly when I :tabe if I run it from wildmenu with lua, but does not function at all, even if run with an au group like ColorScheme or BufEnter when placed elsewhere in my config. I have found out it is being overwritten by the colorscheme code at some point, as the only location in which it works is if I put it at the bottom of lua/colors/highlights.

To my knowledge, this is not available for override specifically, and adding a default config override the colors.init() call in the config portion of nvim-base16 would require copying over the entirety of the colors folder into custom for like 4 lines of code at the bottom of highlights.

An example of the file I used to test the functionality of my code is as follows:
first, I set hl_override in chadrc to "custom.plugins.hl_override:

inside custom.plugins.hl_override.lua:
```
local cmd=vim.cmd

local function bg(group, color)
   cmd("hi " .. group .. " guibg=" .. color)
end

local function fg(group, color)
   cmd("hi " .. group .. " guifg=" .. color)
end

bg("TabLineFill", "#000000")
```
Result: everything works fine. Setting hl_override to false does not call the file in question and everything proceeds normally. Thus, I do not feel a pcall/present check is necessary, since the user must supply a specific path of their own, and we want them to be notified it cannot be found, thus the require statement in highlights.lua.
