### PR TITLE
feat(nvimtree): exclude terminal from window picker

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -17,6 +17,11 @@ g.nvim_tree_indent_markers = 1
 g.nvim_tree_ignore = { ".git", "node_modules", ".cache" }
 g.nvim_tree_quit_on_open = 0 -- closes tree when file's opened
 g.nvim_tree_root_folder_modifier = table.concat { ":t:gs?$?/..", string.rep(" ", 1000), "?:gs?^??" }
+g.nvim_tree_window_picker_exclude = {
+   filetype = { 'notify', 'packer', 'qf' },
+   buftype = {'terminal' },
+}
+
 --
 g.nvim_tree_show_icons = {
    folders = 1,


### PR DESCRIPTION
Taken directly from [nvim-tree](https://github.com/kyazdani42/nvim-tree.lua) readme 


![Screen Shot 2021-11-17 at 10 02 36 AM](https://user-images.githubusercontent.com/5472687/142225767-e0e78a97-a141-4514-a251-3aea22407ba3.png)
