### PR TITLE
fix: LSP diagnostic icons

### DIFF
--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -106,13 +106,14 @@ end
 
 M.lsp_handlers = function()
    local function lspSymbol(name, icon)
-      vim.fn.sign_define("LspDiagnosticsSign" .. name, { text = icon, numhl = "LspDiagnosticsDefault" .. name })
+      local hl = "DiagnosticSign" .. name
+      vim.fn.sign_define(hl, { text = icon, numhl = hl, texthl = hl })
    end
 
    lspSymbol("Error", "")
-   lspSymbol("Information", "")
-   lspSymbol("Hint", "")
-   lspSymbol("Warning", "")
+   lspSymbol("Info", "")
+   lspSymbol("Hint", "")
+   lspSymbol("Warn", "")
 
    vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
       virtual_text = {


### PR DESCRIPTION
LSP diagnostic icons don't show correctly in the gutter. Line numbers are also not colored correctly:
![wrong symbols](https://user-images.githubusercontent.com/10150931/144988780-8f832b02-7c62-443b-b2a5-3d9045dffd24.png)

Fixed (reference: [nvim-lspconfig README](https://github.com/neovim/nvim-lspconfig/wiki/UI-customization#change-diagnostic-symbols-in-the-sign-column-gutter)):
![fixed](https://user-images.githubusercontent.com/10150931/144988942-8dfc910c-c5d2-47fb-a0ac-a53bbbcfdd5e.png)


