### PR TITLE
fix typo in feline repo

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -36,7 +36,7 @@ return packer.startup(function()
    }
 
    use {
-      "feline.nvim/feline.nvim",
+      "feline-nvim/feline.nvim",
       disable = not plugin_settings.status.feline,
       after = "nvim-web-devicons",
       config = override_req("feline", "plugins.configs.statusline"),


### PR DESCRIPTION
User/organization named `feline.nvim` does not exist.
It should be `feline-nvim`.