### PR TITLE
fix: change nvim-tree open directory icon

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -45,7 +45,7 @@ g.nvim_tree_icons = {
       default = "",
       empty = "",
       empty_open = "",
-      open = "",
+      open = "",
       symlink = "",
       symlink_open = "",
    },


### PR DESCRIPTION
Just changes the icon for an open folder, might be opinionated but I think the expected behaviour would be that: 

![image](https://user-images.githubusercontent.com/5472687/147280184-35959b34-a8f8-46b6-911c-ac729b3f3e0d.png)
