### PR TITLE
Feat: Remove no_ignore option from Telescope find files

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -170,8 +170,8 @@ M.telescope = function()
    local m = plugin_maps.telescope
 
    map("n", m.buffers, ":Telescope buffers <CR>")
-   map("n", m.find_files, ":Telescope find_files no_ignore=true <CR>")
-   map("n", m.find_hiddenfiles, ":Telescope find_files hidden=true <CR>")
+   map("n", m.find_files, ":Telescope find_files <CR>")
+   map("n", m.find_hiddenfiles, ":Telescope find_files no_ignore=true hidden=true <CR>")
    map("n", m.git_commits, ":Telescope git_commits <CR>")
    map("n", m.git_status, ":Telescope git_status <CR>")
    map("n", m.help_tags, ":Telescope help_tags <CR>")


### PR DESCRIPTION
Resolves #682 

Prior to this change, searches through large repositories would include
files within the .gitignore, resulting in long search results and many
useless results.  This change results in `find_files` respecting
.gitignore and `find_hiddenfiles` instead being an exhaustive search over
all files within the current directory.