### PR TITLE
fix typo in example_init.lua

### DIFF
--- a/examples/example_init.lua
+++ b/examples/example_init.lua
@@ -18,7 +18,7 @@ end)
 -- you can remove it if you dont have any custom options
 
 -- Install plugins
--- To add new plugins, use the "install_plugin" hook,
+-- To add new plugins, use the "install_plugins" hook,
 
 -- examples below:
 


### PR DESCRIPTION
Hi! I'm new to NvChad.

This comment...

https://github.com/NvChad/NvChad/blob/de9b702f0ed6ec60795156ccb94101774be743e2/examples/example_init.lua#L21

... made me go double check which name is correct ...

https://github.com/NvChad/NvChad/blob/de9b702f0ed6ec60795156ccb94101774be743e2/lua/core/hooks.lua#L4

 Hope this saves someone else a few minutes!

```diff
- install_plugin
+ install_plugins
```