### PR TITLE
fix errors thrown by implicit conversions in latest neovim build

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -22,6 +22,7 @@ M.close_buffer = function(force)
    local function switch_buffer(windows, buf)
       local cur_win = vim.fn.winnr()
       for _, winid in ipairs(windows) do
+         winid = tonumber(winid) or 0
          vim.cmd(string.format("%d wincmd w", vim.fn.win_id2win(winid)))
          vim.cmd(string.format("buffer %d", buf))
       end
@@ -121,7 +122,7 @@ M.hide_statusline = function()
    local hidden = require("core.utils").load_config().plugins.options.statusline.hidden
    local shown = require("core.utils").load_config().plugins.options.statusline.shown
    local api = vim.api
-   local buftype = api.nvim_buf_get_option("%", "ft")
+   local buftype = api.nvim_buf_get_option(0, "ft")
 
    -- shown table from config has the highest priority
    if vim.tbl_contains(shown, buftype) then

--- a/lua/plugins/configs/statusline.lua
+++ b/lua/plugins/configs/statusline.lua
@@ -88,7 +88,7 @@ components.active[1][2] = {
       return " " .. icon .. " " .. filename .. " "
    end,
    enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(winid) > 70
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
    end,
    hl = {
       fg = colors.white,
@@ -105,7 +105,7 @@ components.active[1][3] = {
    end,
 
    enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(winid) > 80
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
    end,
 
    hl = {
@@ -218,7 +218,7 @@ components.active[2][1] = {
       return ""
    end,
    enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(winid) > 80
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
    end,
    hl = { fg = colors.green },
 }
@@ -232,7 +232,7 @@ components.active[3][1] = {
       end
    end,
    enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(winid) > 70
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
    end,
    hl = { fg = colors.grey_fg2, bg = colors.statusline_bg },
 }
@@ -240,7 +240,7 @@ components.active[3][1] = {
 components.active[3][2] = {
    provider = "git_branch",
    enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(winid) > 70
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
    end,
    hl = {
       fg = colors.grey_fg2,
@@ -317,7 +317,7 @@ components.active[3][6] = {
 components.active[3][7] = {
    provider = statusline_style.left,
    enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(winid) > 90
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
    end,
    hl = {
       fg = colors.grey,
@@ -328,7 +328,7 @@ components.active[3][7] = {
 components.active[3][8] = {
    provider = statusline_style.left,
    enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(winid) > 90
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
    end,
    hl = {
       fg = colors.green,
@@ -339,7 +339,7 @@ components.active[3][8] = {
 components.active[3][9] = {
    provider = statusline_style.position_icon,
    enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(winid) > 90
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
    end,
    hl = {
       fg = colors.black,
@@ -362,7 +362,7 @@ components.active[3][10] = {
    end,
 
    enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(winid) > 90
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
    end,
 
    hl = {


### PR DESCRIPTION
neovim/neovim#16745 which was merged into master a bit ago causes errors on opening nvchad due to no longer accepting nil in numerous api functions. The statusline config made use of this implicit conversion and I changed it to convert nil to 0 prior to function call.  A side effect of the implementation of the neovim commit is that '%' no longer can be used to refer to current buffer. This may be changed slightly later as I have seen a few commits over the last few hours updating related functions elsewhere in neovim, but I wouldn't count on it and these edits are necessary to keep nvchad running on up to date builds, and are the 'correct' implementation regardless of what other inputs they decide to reallow.