### PR TITLE
hotfix to :Telescope command flag order

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -169,7 +169,7 @@ M.telescope = function()
 
    map("n", m.buffers, ":Telescope buffers <CR>")
    map("n", m.find_files, ":Telescope find_files <CR>")
-   map("n", m.find_hiddenfiles, ":Telescope follow=true find_files no_ignore=true hidden=true <CR>")
+   map("n", m.find_hiddenfiles, ":Telescope find_files follow=true no_ignore=true hidden=true <CR>")
    map("n", m.git_commits, ":Telescope git_commits <CR>")
    map("n", m.git_status, ":Telescope git_status <CR>")
    map("n", m.help_tags, ":Telescope help_tags <CR>")


### PR DESCRIPTION
Woops

I mixed up the argument ordering in #717

![image](https://user-images.githubusercontent.com/462087/148627065-55d5b703-b729-4daf-82c0-1a9caac76857.png)


<img src="https://media4.giphy.com/media/T1WqKkLY753dZghbu6/giphy.gif"/>