### PR TITLE
Statusline Rewrite for Clarity and Customizability

### DIFF
--- a/lua/plugins/configs/statusline.lua
+++ b/lua/plugins/configs/statusline.lua
@@ -3,44 +3,44 @@ local lsp = require "feline.providers.lsp"
 local lsp_severity = vim.diagnostic.severity
 
 local icon_styles = {
-   default = {
-      left = "",
-      right = " ",
-      main_icon = "  ",
-      vi_mode_icon = " ",
-      position_icon = " ",
-   },
-   arrow = {
-      left = "",
-      right = "",
-      main_icon = "  ",
-      vi_mode_icon = " ",
-      position_icon = " ",
-   },
+	default = {
+		left = "",
+		right = " ",
+		main_icon = "  ",
+		vi_mode_icon = " ",
+		position_icon = " ",
+	},
+	arrow = {
+		left = "",
+		right = "",
+		main_icon = "  ",
+		vi_mode_icon = " ",
+		position_icon = " ",
+	},
 
-   block = {
-      left = " ",
-      right = " ",
-      main_icon = "   ",
-      vi_mode_icon = "  ",
-      position_icon = "  ",
-   },
+	block = {
+		left = " ",
+		right = " ",
+		main_icon = "   ",
+		vi_mode_icon = "  ",
+		position_icon = "  ",
+	},
 
-   round = {
-      left = "",
-      right = "",
-      main_icon = "  ",
-      vi_mode_icon = " ",
-      position_icon = " ",
-   },
+	round = {
+		left = "",
+		right = "",
+		main_icon = "  ",
+		vi_mode_icon = " ",
+		position_icon = " ",
+	},
 
-   slant = {
-      left = " ",
-      right = " ",
-      main_icon = "  ",
-      vi_mode_icon = " ",
-      position_icon = " ",
-   },
+	slant = {
+		left = " ",
+		right = " ",
+		main_icon = "  ",
+		vi_mode_icon = " ",
+		position_icon = " ",
+	},
 }
 
 local config = require("core.utils").load_config().plugins.options.statusline
@@ -54,327 +54,370 @@ local shortline = config.shortline == false and true
 
 -- Initialize the components table
 local components = {
-   active = {},
-   inactive = {},
+	active = {},
+	inactive = {},
 }
 
 table.insert(components.active, {})
 table.insert(components.active, {})
 table.insert(components.active, {})
 
-components.active[1][1] = {
-   provider = statusline_style.main_icon,
+local get_components = function()
+	local M = {}
 
-   hl = {
-      fg = colors.statusline_bg,
-      bg = colors.nord_blue,
-   },
+	M.main_icon = {
+		provider = statusline_style.main_icon,
 
-   right_sep = { str = statusline_style.right, hl = {
-      fg = colors.nord_blue,
-      bg = colors.lightbg,
-   } },
-}
+		hl = {
+			fg = colors.statusline_bg,
+			bg = colors.nord_blue,
+		},
 
-components.active[1][2] = {
-   provider = function()
-      local filename = vim.fn.expand "%:t"
-      local extension = vim.fn.expand "%:e"
-      local icon = require("nvim-web-devicons").get_icon(filename, extension)
-      if icon == nil then
-         icon = " "
-         return icon
-      end
-      return " " .. icon .. " " .. filename .. " "
-   end,
-   enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
-   end,
-   hl = {
-      fg = colors.white,
-      bg = colors.lightbg,
-   },
+		right_sep = { str = statusline_style.right, hl = {
+			fg = colors.nord_blue,
+			bg = colors.lightbg,
+		} },
+	}
 
-   right_sep = { str = statusline_style.right, hl = { fg = colors.lightbg, bg = colors.lightbg2 } },
-}
+	M.file = {
+		provider = function()
+			local filename = vim.fn.expand "%:t"
+			local extension = vim.fn.expand "%:e"
+			local icon = require("nvim-web-devicons").get_icon(filename, extension)
+			if icon == nil then
+				icon = " "
+				return icon
+			end
+			return " " .. icon .. " " .. filename .. " "
+		end,
+		enabled = shortline or function(winid)
+			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
+		end,
+		hl = {
+			fg = colors.white,
+			bg = colors.lightbg,
+		},
 
-components.active[1][3] = {
-   provider = function()
-      local dir_name = vim.fn.fnamemodify(vim.fn.getcwd(), ":t")
-      return "  " .. dir_name .. " "
-   end,
+		right_sep = { str = statusline_style.right, hl = { fg = colors.lightbg, bg = colors.lightbg2 } },
+	}
 
-   enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
-   end,
+	M.dir = {
+		provider = function()
+			local dir_name = vim.fn.fnamemodify(vim.fn.getcwd(), ":t")
+			return "  " .. dir_name .. " "
+		end,
 
-   hl = {
-      fg = colors.grey_fg2,
-      bg = colors.lightbg2,
-   },
-   right_sep = {
-      str = statusline_style.right,
-      hi = {
-         fg = colors.lightbg2,
-         bg = colors.statusline_bg,
-      },
-   },
-}
+		enabled = shortline or function(winid)
+			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
+		end,
 
-components.active[1][4] = {
-   provider = "git_diff_added",
-   hl = {
-      fg = colors.grey_fg2,
-      bg = colors.statusline_bg,
-   },
-   icon = " ",
-}
--- diffModfified
-components.active[1][5] = {
-   provider = "git_diff_changed",
-   hl = {
-      fg = colors.grey_fg2,
-      bg = colors.statusline_bg,
-   },
-   icon = "   ",
-}
--- diffRemove
-components.active[1][6] = {
-   provider = "git_diff_removed",
-   hl = {
-      fg = colors.grey_fg2,
-      bg = colors.statusline_bg,
-   },
-   icon = "  ",
-}
+		hl = {
+			fg = colors.grey_fg2,
+			bg = colors.lightbg2,
+		},
+		right_sep = {
+			str = statusline_style.right,
+			hi = {
+				fg = colors.lightbg2,
+				bg = colors.statusline_bg,
+			},
+		},
+	}
 
-components.active[1][7] = {
-   provider = "diagnostic_errors",
-   enabled = function()
-      return lsp.diagnostics_exist(lsp_severity.ERROR)
-   end,
+	M.git_added = {
+		provider = "git_diff_added",
+		hl = {
+			fg = colors.grey_fg2,
+			bg = colors.statusline_bg,
+		},
+		icon = " ",
+	}
 
-   hl = { fg = colors.red },
-   icon = "  ",
-}
+	M.git_modified = {
+		provider = "git_diff_changed",
+		hl = {
+			fg = colors.grey_fg2,
+			bg = colors.statusline_bg,
+		},
+		icon = "   ",
+	}
 
-components.active[1][8] = {
-   provider = "diagnostic_warnings",
-   enabled = function()
-      return lsp.diagnostics_exist(lsp_severity.WARN)
-   end,
-   hl = { fg = colors.yellow },
-   icon = "  ",
-}
+	M.git_removed = {
+		provider = "git_diff_removed",
+		hl = {
+			fg = colors.grey_fg2,
+			bg = colors.statusline_bg,
+		},
+		icon = "  ",
+	}
 
-components.active[1][9] = {
-   provider = "diagnostic_hints",
-   enabled = function()
-      return lsp.diagnostics_exist(lsp_severity.HINT)
-   end,
-   hl = { fg = colors.grey_fg2 },
-   icon = "  ",
-}
+	M.diagnostic_errors = {
+		provider = "diagnostic_errors",
+		enabled = function()
+			return lsp.diagnostics_exist(lsp_severity.ERROR)
+		end,
 
-components.active[1][10] = {
-   provider = "diagnostic_info",
-   enabled = function()
-      return lsp.diagnostics_exist(lsp_severity.INFO)
-   end,
-   hl = { fg = colors.green },
-   icon = "  ",
-}
+		hl = { fg = colors.red },
+		icon = "  ",
+	}
 
-components.active[2][1] = {
-   provider = function()
-      local Lsp = vim.lsp.util.get_progress_messages()[1]
+	M.diagnostic_warnings= {
+		provider = "diagnostic_warnings",
+		enabled = function()
+			return lsp.diagnostics_exist(lsp_severity.WARN)
+		end,
+		hl = { fg = colors.yellow },
+		icon = "  ",
+	}
 
-      if Lsp then
-         local msg = Lsp.message or ""
-         local percentage = Lsp.percentage or 0
-         local title = Lsp.title or ""
-         local spinners = {
-            "",
-            "",
-            "",
-         }
+	M.diagnostic_hints = {
+		provider = "diagnostic_hints",
+		enabled = function()
+			return lsp.diagnostics_exist(lsp_severity.HINT)
+		end,
+		hl = { fg = colors.grey_fg2 },
+		icon = "  ",
+	}
 
-         local success_icon = {
-            "",
-            "",
-            "",
-         }
+	M.dianostic_info ={
+		provider = "diagnostic_info",
+		enabled = function()
+			return lsp.diagnostics_exist(lsp_severity.INFO)
+		end,
+		hl = { fg = colors.green },
+		icon = "  ",
+	}
 
-         local ms = vim.loop.hrtime() / 1000000
-         local frame = math.floor(ms / 120) % #spinners
+	M.lsp_progress = {
+		provider = function()
+			local Lsp = vim.lsp.util.get_progress_messages()[1]
 
-         if percentage >= 70 then
-            return string.format(" %%<%s %s %s (%s%%%%) ", success_icon[frame + 1], title, msg, percentage)
-         end
+			if Lsp then
+				local msg = Lsp.message or ""
+				local percentage = Lsp.percentage or 0
+				local title = Lsp.title or ""
+				local spinners = {
+					"",
+					"",
+					"",
+				}
 
-         return string.format(" %%<%s %s %s (%s%%%%) ", spinners[frame + 1], title, msg, percentage)
-      end
+				local success_icon = {
+					"",
+					"",
+					"",
+				}
 
-      return ""
-   end,
-   enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
-   end,
-   hl = { fg = colors.green },
-}
+				local ms = vim.loop.hrtime() / 1000000
+				local frame = math.floor(ms / 120) % #spinners
 
-components.active[3][1] = {
-   provider = function()
-      if next(vim.lsp.buf_get_clients()) ~= nil then
-         return "  LSP"
-      else
-         return ""
-      end
-   end,
-   enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
-   end,
-   hl = { fg = colors.grey_fg2, bg = colors.statusline_bg },
-}
+				if percentage >= 70 then
+					return string.format(" %%<%s %s %s (%s%%%%) ", success_icon[frame + 1], title, msg, percentage)
+				end
 
-components.active[3][2] = {
-   provider = "git_branch",
-   enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
-   end,
-   hl = {
-      fg = colors.grey_fg2,
-      bg = colors.statusline_bg,
-   },
-   icon = "  ",
-}
+				return string.format(" %%<%s %s %s (%s%%%%) ", spinners[frame + 1], title, msg, percentage)
+			end
 
-components.active[3][3] = {
-   provider = " " .. statusline_style.left,
-   hl = {
-      fg = colors.one_bg2,
-      bg = colors.statusline_bg,
-   },
-}
+			return ""
+		end,
+		enabled = shortline or function(winid)
+			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
+		end,
+		hl = { fg = colors.green },
+	}
 
-local mode_colors = {
-   ["n"] = { "NORMAL", colors.red },
-   ["no"] = { "N-PENDING", colors.red },
-   ["i"] = { "INSERT", colors.dark_purple },
-   ["ic"] = { "INSERT", colors.dark_purple },
-   ["t"] = { "TERMINAL", colors.green },
-   ["v"] = { "VISUAL", colors.cyan },
-   ["V"] = { "V-LINE", colors.cyan },
-   [""] = { "V-BLOCK", colors.cyan },
-   ["R"] = { "REPLACE", colors.orange },
-   ["Rv"] = { "V-REPLACE", colors.orange },
-   ["s"] = { "SELECT", colors.nord_blue },
-   ["S"] = { "S-LINE", colors.nord_blue },
-   [""] = { "S-BLOCK", colors.nord_blue },
-   ["c"] = { "COMMAND", colors.pink },
-   ["cv"] = { "COMMAND", colors.pink },
-   ["ce"] = { "COMMAND", colors.pink },
-   ["r"] = { "PROMPT", colors.teal },
-   ["rm"] = { "MORE", colors.teal },
-   ["r?"] = { "CONFIRM", colors.teal },
-   ["!"] = { "SHELL", colors.green },
-}
+	M.lsp = {
+		provider = function()
+			if next(vim.lsp.buf_get_clients()) ~= nil then
+				return "  LSP"
+			else
+				return ""
+			end
+		end,
+		enabled = shortline or function(winid)
+			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
+		end,
+		hl = { fg = colors.grey_fg2, bg = colors.statusline_bg },
+	}
 
-local chad_mode_hl = function()
-   return {
-      fg = mode_colors[vim.fn.mode()][2],
-      bg = colors.one_bg,
-   }
+	M.git_branch = {
+		provider = "git_branch",
+		enabled = shortline or function(winid)
+			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
+		end,
+		hl = {
+			fg = colors.grey_fg2,
+			bg = colors.statusline_bg,
+		},
+		icon = "  ",
+	}
+
+	M.git_right_separator = {
+		provider = " " .. statusline_style.left,
+		hl = {
+			fg = colors.one_bg2,
+			bg = colors.statusline_bg,
+		},
+	}
+
+	local mode_colors = {
+		["n"] = { "NORMAL", colors.red },
+		["no"] = { "N-PENDING", colors.red },
+		["i"] = { "INSERT", colors.dark_purple },
+		["ic"] = { "INSERT", colors.dark_purple },
+		["t"] = { "TERMINAL", colors.green },
+		["v"] = { "VISUAL", colors.cyan },
+		["V"] = { "V-LINE", colors.cyan },
+		[""] = { "V-BLOCK", colors.cyan },
+		["R"] = { "REPLACE", colors.orange },
+		["Rv"] = { "V-REPLACE", colors.orange },
+		["s"] = { "SELECT", colors.nord_blue },
+		["S"] = { "S-LINE", colors.nord_blue },
+		[""] = { "S-BLOCK", colors.nord_blue },
+		["c"] = { "COMMAND", colors.pink },
+		["cv"] = { "COMMAND", colors.pink },
+		["ce"] = { "COMMAND", colors.pink },
+		["r"] = { "PROMPT", colors.teal },
+		["rm"] = { "MORE", colors.teal },
+		["r?"] = { "CONFIRM", colors.teal },
+		["!"] = { "SHELL", colors.green },
+	}
+
+	local chad_mode_hl = function()
+		return {
+			fg = mode_colors[vim.fn.mode()][2],
+			bg = colors.one_bg,
+		}
+	end
+
+	M.mode_left_separator = {
+		provider = statusline_style.left,
+		hl = function()
+			return {
+				fg = mode_colors[vim.fn.mode()][2],
+				bg = colors.one_bg2,
+			}
+		end,
+	}
+
+	M.mode_icon = {
+		provider = statusline_style.vi_mode_icon,
+		hl = function()
+			return {
+				fg = colors.statusline_bg,
+				bg = mode_colors[vim.fn.mode()][2],
+			}
+		end,
+	}
+
+	M.mode_string = {
+		provider = function()
+			return " " .. mode_colors[vim.fn.mode()][1] .. " "
+		end,
+		hl = chad_mode_hl,
+	}
+
+	M.loc_spacer_left = {
+		provider = statusline_style.left,
+		enabled = shortline or function(winid)
+			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
+		end,
+		hl = {
+			fg = colors.grey,
+			bg = colors.one_bg,
+		}
+	}
+
+	M.loc_separator_left = {
+		provider = statusline_style.left,
+		enabled = shortline or function(winid)
+			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
+		end,
+		hl = {
+			fg = colors.green,
+			bg = colors.grey,
+		},
+	}
+
+	M.loc_position_icon = {
+		provider = statusline_style.position_icon,
+		enabled = shortline or function(winid)
+			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
+		end,
+		hl = {
+			fg = colors.black,
+			bg = colors.green,
+		}
+	}
+
+	M.loc_position_text = {
+		provider = function()
+			local current_line = vim.fn.line "."
+			local total_line = vim.fn.line "$"
+
+			if current_line == 1 then
+				return " Top "
+			elseif current_line == vim.fn.line "$" then
+				return " Bot "
+			end
+			local result, _ = math.modf((current_line / total_line) * 100)
+			return " " .. result .. "%% "
+		end,
+
+		enabled = shortline or function(winid)
+			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
+		end,
+
+		hl = {
+			fg = colors.green,
+			bg = colors.one_bg,
+		},
+	}
+	return M
 end
 
-components.active[3][4] = {
-   provider = statusline_style.left,
-   hl = function()
-      return {
-         fg = mode_colors[vim.fn.mode()][2],
-         bg = colors.one_bg2,
-      }
-   end,
-}
+local components_list = get_components()
 
-components.active[3][5] = {
-   provider = statusline_style.vi_mode_icon,
-   hl = function()
-      return {
-         fg = colors.statusline_bg,
-         bg = mode_colors[vim.fn.mode()][2],
-      }
-   end,
-}
+local left = {}
+local right = {}
+local middle = {}
 
-components.active[3][6] = {
-   provider = function()
-      return " " .. mode_colors[vim.fn.mode()][1] .. " "
-   end,
-   hl = chad_mode_hl,
-}
+table.insert(left, components_list.main_icon)
+table.insert(left, components_list.file)
+table.insert(left, components_list.dir)
 
-components.active[3][7] = {
-   provider = statusline_style.left,
-   enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
-   end,
-   hl = {
-      fg = colors.grey,
-      bg = colors.one_bg,
-   },
-}
+table.insert(left, components_list.git_added)
+table.insert(left, components_list.git_modified)
+table.insert(left, components_list.git_removed)
 
-components.active[3][8] = {
-   provider = statusline_style.left,
-   enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
-   end,
-   hl = {
-      fg = colors.green,
-      bg = colors.grey,
-   },
-}
+table.insert(left, components_list.diagnostic_errors)
+table.insert(left, components_list.diagnostic_warnings)
+table.insert(left, components_list.diagnostic_hints)
+table.insert(left, components_list.diagnostic_info)
 
-components.active[3][9] = {
-   provider = statusline_style.position_icon,
-   enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
-   end,
-   hl = {
-      fg = colors.black,
-      bg = colors.green,
-   },
-}
+table.insert(middle, components_list.lsp_progress)
 
-components.active[3][10] = {
-   provider = function()
-      local current_line = vim.fn.line "."
-      local total_line = vim.fn.line "$"
+table.insert(right, components_list.lsp)
+table.insert(right, components_list.git_branch)
+table.insert(right, components_list.git_right_separator)
 
-      if current_line == 1 then
-         return " Top "
-      elseif current_line == vim.fn.line "$" then
-         return " Bot "
-      end
-      local result, _ = math.modf((current_line / total_line) * 100)
-      return " " .. result .. "%% "
-   end,
+table.insert(right, components_list.mode_left_separator)
+table.insert(right, components_list.mode_mode_icon)
+table.insert(right, components_list.mode_mode_string)
 
-   enabled = shortline or function(winid)
-      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
-   end,
+table.insert(right, components_list.loc_spacer_left)
+table.insert(right, components_list.loc_separator_left)
+table.insert(right, components_list.loc_position_icon)
+table.insert(right, components_list.loc_position_text)
 
-   hl = {
-      fg = colors.green,
-      bg = colors.one_bg,
-   },
-}
+components.active[1] = left
+components.active[2] = middle
+components.active[3] = right
 
 require("feline").setup {
-   theme = {
-      bg = colors.statusline_bg,
-      fg = colors.fg,
-   },
-   components = components,
+	theme = {
+		bg = colors.statusline_bg,
+		fg = colors.fg,
+	},
+	components = components,
 }

--- a/lua/plugins/configs/statusline.lua
+++ b/lua/plugins/configs/statusline.lua
@@ -1,46 +1,46 @@
-local colors = require("colors").get()
+ local colors = require("colors").get()
 local lsp = require "feline.providers.lsp"
 local lsp_severity = vim.diagnostic.severity
 
 local icon_styles = {
-	default = {
-		left = "",
-		right = " ",
-		main_icon = "  ",
-		vi_mode_icon = " ",
-		position_icon = " ",
-	},
-	arrow = {
-		left = "",
-		right = "",
-		main_icon = "  ",
-		vi_mode_icon = " ",
-		position_icon = " ",
-	},
+   default = {
+      left = "",
+      right = " ",
+      main_icon = "  ",
+      vi_mode_icon = " ",
+      position_icon = " ",
+   },
+   arrow = {
+      left = "",
+      right = "",
+      main_icon = "  ",
+      vi_mode_icon = " ",
+      position_icon = " ",
+   },
 
-	block = {
-		left = " ",
-		right = " ",
-		main_icon = "   ",
-		vi_mode_icon = "  ",
-		position_icon = "  ",
-	},
+   block = {
+      left = " ",
+      right = " ",
+      main_icon = "   ",
+      vi_mode_icon = "  ",
+      position_icon = "  ",
+   },
 
-	round = {
-		left = "",
-		right = "",
-		main_icon = "  ",
-		vi_mode_icon = " ",
-		position_icon = " ",
-	},
+   round = {
+      left = "",
+      right = "",
+      main_icon = "  ",
+      vi_mode_icon = " ",
+      position_icon = " ",
+   },
 
-	slant = {
-		left = " ",
-		right = " ",
-		main_icon = "  ",
-		vi_mode_icon = " ",
-		position_icon = " ",
-	},
+   slant = {
+      left = " ",
+      right = " ",
+      main_icon = "  ",
+      vi_mode_icon = " ",
+      position_icon = " ",
+   },
 }
 
 local config = require("core.utils").load_config().plugins.options.statusline
@@ -54,370 +54,366 @@ local shortline = config.shortline == false and true
 
 -- Initialize the components table
 local components = {
-	active = {},
-	inactive = {},
+   active = {},
 }
 
-table.insert(components.active, {})
-table.insert(components.active, {})
-table.insert(components.active, {})
+local main_icon = {
+   provider = statusline_style.main_icon,
 
-local get_components = function()
-	local M = {}
+   hl = {
+      fg = colors.statusline_bg,
+      bg = colors.nord_blue,
+   },
 
-	M.main_icon = {
-		provider = statusline_style.main_icon,
+   right_sep = { str = statusline_style.right, hl = {
+      fg = colors.nord_blue,
+      bg = colors.lightbg,
+   } },
+}
 
-		hl = {
-			fg = colors.statusline_bg,
-			bg = colors.nord_blue,
-		},
+local file_name = {
+   provider = function()
+      local filename = vim.fn.expand "%:t"
+      local extension = vim.fn.expand "%:e"
+      local icon = require("nvim-web-devicons").get_icon(filename, extension)
+      if icon == nil then
+         icon = " "
+         return icon
+      end
+      return " " .. icon .. " " .. filename .. " "
+   end,
+   enabled = shortline or function(winid)
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
+   end,
+   hl = {
+      fg = colors.white,
+      bg = colors.lightbg,
+   },
 
-		right_sep = { str = statusline_style.right, hl = {
-			fg = colors.nord_blue,
-			bg = colors.lightbg,
-		} },
-	}
+   right_sep = { str = statusline_style.right, hl = { fg = colors.lightbg, bg = colors.lightbg2 } },
+}
 
-	M.file = {
-		provider = function()
-			local filename = vim.fn.expand "%:t"
-			local extension = vim.fn.expand "%:e"
-			local icon = require("nvim-web-devicons").get_icon(filename, extension)
-			if icon == nil then
-				icon = " "
-				return icon
-			end
-			return " " .. icon .. " " .. filename .. " "
-		end,
-		enabled = shortline or function(winid)
-			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
-		end,
-		hl = {
-			fg = colors.white,
-			bg = colors.lightbg,
-		},
+local dir_name = {
+   provider = function()
+      local dir_name = vim.fn.fnamemodify(vim.fn.getcwd(), ":t")
+      return "  " .. dir_name .. " "
+   end,
 
-		right_sep = { str = statusline_style.right, hl = { fg = colors.lightbg, bg = colors.lightbg2 } },
-	}
+   enabled = shortline or function(winid)
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
+   end,
 
-	M.dir = {
-		provider = function()
-			local dir_name = vim.fn.fnamemodify(vim.fn.getcwd(), ":t")
-			return "  " .. dir_name .. " "
-		end,
+   hl = {
+      fg = colors.grey_fg2,
+      bg = colors.lightbg2,
+   },
+   right_sep = {
+      str = statusline_style.right,
+      hi = {
+         fg = colors.lightbg2,
+         bg = colors.statusline_bg,
+      },
+   },
+}
 
-		enabled = shortline or function(winid)
-			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
-		end,
+local diff = {
+   add = {
+      provider = "git_diff_added",
+      hl = {
+         fg = colors.grey_fg2,
+         bg = colors.statusline_bg,
+      },
+      icon = " ",
+   },
 
-		hl = {
-			fg = colors.grey_fg2,
-			bg = colors.lightbg2,
-		},
-		right_sep = {
-			str = statusline_style.right,
-			hi = {
-				fg = colors.lightbg2,
-				bg = colors.statusline_bg,
-			},
-		},
-	}
+   change = {
+      provider = "git_diff_changed",
+      hl = {
+         fg = colors.grey_fg2,
+         bg = colors.statusline_bg,
+      },
+      icon = "   ",
+   },
 
-	M.git_added = {
-		provider = "git_diff_added",
-		hl = {
-			fg = colors.grey_fg2,
-			bg = colors.statusline_bg,
-		},
-		icon = " ",
-	}
+   remove = {
+      provider = "git_diff_removed",
+      hl = {
+         fg = colors.grey_fg2,
+         bg = colors.statusline_bg,
+      },
+      icon = "  ",
+   },
+}
 
-	M.git_modified = {
-		provider = "git_diff_changed",
-		hl = {
-			fg = colors.grey_fg2,
-			bg = colors.statusline_bg,
-		},
-		icon = "   ",
-	}
+local git_branch = {
+   provider = "git_branch",
+   enabled = shortline or function(winid)
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
+   end,
+   hl = {
+      fg = colors.grey_fg2,
+      bg = colors.statusline_bg,
+   },
+   icon = "  ",
+}
 
-	M.git_removed = {
-		provider = "git_diff_removed",
-		hl = {
-			fg = colors.grey_fg2,
-			bg = colors.statusline_bg,
-		},
-		icon = "  ",
-	}
+local diagnostic = {
+   errors = {
+      provider = "diagnostic_errors",
+      enabled = function()
+         return lsp.diagnostics_exist(lsp_severity.ERROR)
+      end,
 
-	M.diagnostic_errors = {
-		provider = "diagnostic_errors",
-		enabled = function()
-			return lsp.diagnostics_exist(lsp_severity.ERROR)
-		end,
+      hl = { fg = colors.red },
+      icon = "  ",
+   },
 
-		hl = { fg = colors.red },
-		icon = "  ",
-	}
+   warning = {
+      provider = "diagnostic_warnings",
+      enabled = function()
+         return lsp.diagnostics_exist(lsp_severity.WARN)
+      end,
+      hl = { fg = colors.yellow },
+      icon = "  ",
+   },
 
-	M.diagnostic_warnings= {
-		provider = "diagnostic_warnings",
-		enabled = function()
-			return lsp.diagnostics_exist(lsp_severity.WARN)
-		end,
-		hl = { fg = colors.yellow },
-		icon = "  ",
-	}
+   hint = {
+      provider = "diagnostic_hints",
+      enabled = function()
+         return lsp.diagnostics_exist(lsp_severity.HINT)
+      end,
+      hl = { fg = colors.grey_fg2 },
+      icon = "  ",
+   },
 
-	M.diagnostic_hints = {
-		provider = "diagnostic_hints",
-		enabled = function()
-			return lsp.diagnostics_exist(lsp_severity.HINT)
-		end,
-		hl = { fg = colors.grey_fg2 },
-		icon = "  ",
-	}
+   info = {
+      provider = "diagnostic_info",
+      enabled = function()
+         return lsp.diagnostics_exist(lsp_severity.INFO)
+      end,
+      hl = { fg = colors.green },
+      icon = "  ",
+   },
+}
 
-	M.dianostic_info ={
-		provider = "diagnostic_info",
-		enabled = function()
-			return lsp.diagnostics_exist(lsp_severity.INFO)
-		end,
-		hl = { fg = colors.green },
-		icon = "  ",
-	}
+local lsp_progress = {
+   provider = function()
+      local Lsp = vim.lsp.util.get_progress_messages()[1]
 
-	M.lsp_progress = {
-		provider = function()
-			local Lsp = vim.lsp.util.get_progress_messages()[1]
+      if Lsp then
+         local msg = Lsp.message or ""
+         local percentage = Lsp.percentage or 0
+         local title = Lsp.title or ""
+         local spinners = {
+            "",
+            "",
+            "",
+         }
 
-			if Lsp then
-				local msg = Lsp.message or ""
-				local percentage = Lsp.percentage or 0
-				local title = Lsp.title or ""
-				local spinners = {
-					"",
-					"",
-					"",
-				}
+         local success_icon = {
+            "",
+            "",
+            "",
+         }
 
-				local success_icon = {
-					"",
-					"",
-					"",
-				}
+         local ms = vim.loop.hrtime() / 1000000
+         local frame = math.floor(ms / 120) % #spinners
 
-				local ms = vim.loop.hrtime() / 1000000
-				local frame = math.floor(ms / 120) % #spinners
+         if percentage >= 70 then
+            return string.format(" %%<%s %s %s (%s%%%%) ", success_icon[frame + 1], title, msg, percentage)
+         end
 
-				if percentage >= 70 then
-					return string.format(" %%<%s %s %s (%s%%%%) ", success_icon[frame + 1], title, msg, percentage)
-				end
+         return string.format(" %%<%s %s %s (%s%%%%) ", spinners[frame + 1], title, msg, percentage)
+      end
 
-				return string.format(" %%<%s %s %s (%s%%%%) ", spinners[frame + 1], title, msg, percentage)
-			end
+      return ""
+   end,
+   enabled = shortline or function(winid)
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
+   end,
+   hl = { fg = colors.green },
+}
 
-			return ""
-		end,
-		enabled = shortline or function(winid)
-			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
-		end,
-		hl = { fg = colors.green },
-	}
+local lsp_icon = {
+   provider = function()
+      if next(vim.lsp.buf_get_clients()) ~= nil then
+         return "  LSP"
+      else
+         return ""
+      end
+   end,
+   enabled = shortline or function(winid)
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
+   end,
+   hl = { fg = colors.grey_fg2, bg = colors.statusline_bg },
+}
 
-	M.lsp = {
-		provider = function()
-			if next(vim.lsp.buf_get_clients()) ~= nil then
-				return "  LSP"
-			else
-				return ""
-			end
-		end,
-		enabled = shortline or function(winid)
-			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
-		end,
-		hl = { fg = colors.grey_fg2, bg = colors.statusline_bg },
-	}
+local mode_colors = {
+   ["n"] = { "NORMAL", colors.red },
+   ["no"] = { "N-PENDING", colors.red },
+   ["i"] = { "INSERT", colors.dark_purple },
+   ["ic"] = { "INSERT", colors.dark_purple },
+   ["t"] = { "TERMINAL", colors.green },
+   ["v"] = { "VISUAL", colors.cyan },
+   ["V"] = { "V-LINE", colors.cyan },
+   [""] = { "V-BLOCK", colors.cyan },
+   ["R"] = { "REPLACE", colors.orange },
+   ["Rv"] = { "V-REPLACE", colors.orange },
+   ["s"] = { "SELECT", colors.nord_blue },
+   ["S"] = { "S-LINE", colors.nord_blue },
+   [""] = { "S-BLOCK", colors.nord_blue },
+   ["c"] = { "COMMAND", colors.pink },
+   ["cv"] = { "COMMAND", colors.pink },
+   ["ce"] = { "COMMAND", colors.pink },
+   ["r"] = { "PROMPT", colors.teal },
+   ["rm"] = { "MORE", colors.teal },
+   ["r?"] = { "CONFIRM", colors.teal },
+   ["!"] = { "SHELL", colors.green },
+}
 
-	M.git_branch = {
-		provider = "git_branch",
-		enabled = shortline or function(winid)
-			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
-		end,
-		hl = {
-			fg = colors.grey_fg2,
-			bg = colors.statusline_bg,
-		},
-		icon = "  ",
-	}
-
-	M.git_right_separator = {
-		provider = " " .. statusline_style.left,
-		hl = {
-			fg = colors.one_bg2,
-			bg = colors.statusline_bg,
-		},
-	}
-
-	local mode_colors = {
-		["n"] = { "NORMAL", colors.red },
-		["no"] = { "N-PENDING", colors.red },
-		["i"] = { "INSERT", colors.dark_purple },
-		["ic"] = { "INSERT", colors.dark_purple },
-		["t"] = { "TERMINAL", colors.green },
-		["v"] = { "VISUAL", colors.cyan },
-		["V"] = { "V-LINE", colors.cyan },
-		[""] = { "V-BLOCK", colors.cyan },
-		["R"] = { "REPLACE", colors.orange },
-		["Rv"] = { "V-REPLACE", colors.orange },
-		["s"] = { "SELECT", colors.nord_blue },
-		["S"] = { "S-LINE", colors.nord_blue },
-		[""] = { "S-BLOCK", colors.nord_blue },
-		["c"] = { "COMMAND", colors.pink },
-		["cv"] = { "COMMAND", colors.pink },
-		["ce"] = { "COMMAND", colors.pink },
-		["r"] = { "PROMPT", colors.teal },
-		["rm"] = { "MORE", colors.teal },
-		["r?"] = { "CONFIRM", colors.teal },
-		["!"] = { "SHELL", colors.green },
-	}
-
-	local chad_mode_hl = function()
-		return {
-			fg = mode_colors[vim.fn.mode()][2],
-			bg = colors.one_bg,
-		}
-	end
-
-	M.mode_left_separator = {
-		provider = statusline_style.left,
-		hl = function()
-			return {
-				fg = mode_colors[vim.fn.mode()][2],
-				bg = colors.one_bg2,
-			}
-		end,
-	}
-
-	M.mode_icon = {
-		provider = statusline_style.vi_mode_icon,
-		hl = function()
-			return {
-				fg = colors.statusline_bg,
-				bg = mode_colors[vim.fn.mode()][2],
-			}
-		end,
-	}
-
-	M.mode_string = {
-		provider = function()
-			return " " .. mode_colors[vim.fn.mode()][1] .. " "
-		end,
-		hl = chad_mode_hl,
-	}
-
-	M.loc_spacer_left = {
-		provider = statusline_style.left,
-		enabled = shortline or function(winid)
-			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
-		end,
-		hl = {
-			fg = colors.grey,
-			bg = colors.one_bg,
-		}
-	}
-
-	M.loc_separator_left = {
-		provider = statusline_style.left,
-		enabled = shortline or function(winid)
-			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
-		end,
-		hl = {
-			fg = colors.green,
-			bg = colors.grey,
-		},
-	}
-
-	M.loc_position_icon = {
-		provider = statusline_style.position_icon,
-		enabled = shortline or function(winid)
-			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
-		end,
-		hl = {
-			fg = colors.black,
-			bg = colors.green,
-		}
-	}
-
-	M.loc_position_text = {
-		provider = function()
-			local current_line = vim.fn.line "."
-			local total_line = vim.fn.line "$"
-
-			if current_line == 1 then
-				return " Top "
-			elseif current_line == vim.fn.line "$" then
-				return " Bot "
-			end
-			local result, _ = math.modf((current_line / total_line) * 100)
-			return " " .. result .. "%% "
-		end,
-
-		enabled = shortline or function(winid)
-			return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
-		end,
-
-		hl = {
-			fg = colors.green,
-			bg = colors.one_bg,
-		},
-	}
-	return M
+local chad_mode_hl = function()
+   return {
+      fg = mode_colors[vim.fn.mode()][2],
+      bg = colors.one_bg,
+   }
 end
 
-local components_list = get_components()
+local empty_space = {
+   provider = " " .. statusline_style.left,
+   hl = {
+      fg = colors.one_bg2,
+      bg = colors.statusline_bg,
+   },
+}
 
+-- this matches the vi mode color
+local empty_spaceColored = {
+   provider = statusline_style.left,
+   hl = function()
+      return {
+         fg = mode_colors[vim.fn.mode()][2],
+         bg = colors.one_bg2,
+      }
+   end,
+}
+
+local mode_icon = {
+   provider = statusline_style.vi_mode_icon,
+   hl = function()
+      return {
+         fg = colors.statusline_bg,
+         bg = mode_colors[vim.fn.mode()][2],
+      }
+   end,
+}
+
+local empty_space2 = {
+   provider = function()
+      return " " .. mode_colors[vim.fn.mode()][1] .. " "
+   end,
+   hl = chad_mode_hl,
+}
+
+local separator_right = {
+   provider = statusline_style.left,
+   enabled = shortline or function(winid)
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
+   end,
+   hl = {
+      fg = colors.grey,
+      bg = colors.one_bg,
+   },
+}
+
+local separator_right2 = {
+   provider = statusline_style.left,
+   enabled = shortline or function(winid)
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
+   end,
+   hl = {
+      fg = colors.green,
+      bg = colors.grey,
+   },
+}
+
+local position_icon = {
+   provider = statusline_style.position_icon,
+   enabled = shortline or function(winid)
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
+   end,
+   hl = {
+      fg = colors.black,
+      bg = colors.green,
+   },
+}
+
+local current_line = {
+   provider = function()
+      local current_line = vim.fn.line "."
+      local total_line = vim.fn.line "$"
+
+      if current_line == 1 then
+         return " Top "
+      elseif current_line == vim.fn.line "$" then
+         return " Bot "
+      end
+      local result, _ = math.modf((current_line / total_line) * 100)
+      return " " .. result .. "%% "
+   end,
+
+   enabled = shortline or function(winid)
+      return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
+   end,
+
+   hl = {
+      fg = colors.green,
+      bg = colors.one_bg,
+   },
+}
+
+local function add_table(a, b)
+   table.insert(a, b)
+end
+
+-- components are divided in 3 sections
 local left = {}
-local right = {}
 local middle = {}
+local right = {}
 
-table.insert(left, components_list.main_icon)
-table.insert(left, components_list.file)
-table.insert(left, components_list.dir)
+-- left
+add_table(left, main_icon)
+add_table(left, file_name)
+add_table(left, dir_name)
+add_table(left, diff.add)
+add_table(left, diff.change)
+add_table(left, diff.remove)
+add_table(left, diagnostic.error)
+add_table(left, diagnostic.warning)
+add_table(left, diagnostic.hint)
+add_table(left, diagnostic.info)
 
-table.insert(left, components_list.git_added)
-table.insert(left, components_list.git_modified)
-table.insert(left, components_list.git_removed)
+add_table(middle, lsp_progress)
 
-table.insert(left, components_list.diagnostic_errors)
-table.insert(left, components_list.diagnostic_warnings)
-table.insert(left, components_list.diagnostic_hints)
-table.insert(left, components_list.diagnostic_info)
-
-table.insert(middle, components_list.lsp_progress)
-
-table.insert(right, components_list.lsp)
-table.insert(right, components_list.git_branch)
-table.insert(right, components_list.git_right_separator)
-
-table.insert(right, components_list.mode_left_separator)
-table.insert(right, components_list.mode_mode_icon)
-table.insert(right, components_list.mode_mode_string)
-
-table.insert(right, components_list.loc_spacer_left)
-table.insert(right, components_list.loc_separator_left)
-table.insert(right, components_list.loc_position_icon)
-table.insert(right, components_list.loc_position_text)
+-- right
+add_table(right, lsp_icon)
+add_table(right, git_branch)
+add_table(right, empty_space)
+add_table(right, empty_spaceColored)
+add_table(right, mode_icon)
+add_table(right, empty_space2)
+add_table(right, separator_right)
+add_table(right, separator_right2)
+add_table(right, position_icon)
+add_table(right, current_line)
 
 components.active[1] = left
 components.active[2] = middle
 components.active[3] = right
 
 require("feline").setup {
-	theme = {
-		bg = colors.statusline_bg,
-		fg = colors.fg,
-	},
-	components = components,
+   theme = {
+      bg = colors.statusline_bg,
+      fg = colors.fg,
+   },
+   components = components,
 }


### PR DESCRIPTION
A while ago I wanted to override the default NvChad statusline with a couple of changes, and quickly found that adding any new component, or removing any component would require changing the number in the insert function of every subsequent component in the corresponding area of the statusline, namely being the left (1), middle(2) -but only one component so non-issue really, and right(3). Now there are quite a few components in the NvChad statusline and this quickly became extremely cumbersome. While my statusline now differs greatly from NvChad, the flexibility of my method has been invaluable in customizing it for clarity and time saving purposes so I felt updating it here might be a benefit to many individuals.

The NvChad statusline is appealing to many users and has some functionality that is likely non-trivial for inexperienced or even possibly some intermediate users to implement on their own, and thus turning it into something which is a bit more 'hacker friendly' might be a great benefit to some users. I know that for many of my overrides, especially ones written before I became more comfortable with lua, started with the NvChad configuration and go from there.

My changes create a function which returns a table of named components. Some components which logically belong in groups (like the 3 git diff ones or the 4 diagnostic ones) have been grouped into a nested table such that components_list.diagnostics.errors refers to the error component for instance, while lsp progress and lsp as more isolated components are simply referred to as components_list.lsp_progress and components_list.lsp respectively for their insertion

Furthermore, 1,2, and 3 have been assigned the values of left, middle, and right so that it is clear in the insertion where they are going. All insertions take place near the bottom of the code, so refer there to see the updated methodology. A massive benefit of this approach is that changing the order of components, or inserting a new one is as simple as changing the sequential order of the insertions or placing a new one between the components you wish to place it. Removal is equally easy by just taking one out. In the current functionality, removing the 'directory' component would require decrementing every subsequent left component from components.active[1][4] -> components.active[1][10] to be components.active[1][3] -> components.active[1][9].

in my implementation it is as simple as making the following comment:
```
table.insert(left, components_list.main_icon)
table.insert(left, components_list.file)
--table.insert(left, components_list.dir)
table.insert(left, components_list.git.added)
table.insert(left, components_list.git.modified)
table.insert(left, components_list.git.removed)
table.insert(left, components_list.diagnostics.errors)
table.insert(left, components_list.diagnostics.warnings)
table.insert(left, components_list.diagnostics.hints)
table.insert(left, components_list.diagnostics.info)
```

All functionality and display seemed to be the exact same as when I used a vanilla NvChad config in my tests but I would greatly appreciate someone else testing this and giving confirmation as it is possible I missed something.

Personally I like having the components in a separate file and getting them through a require, but since the original implementation was in one file I kept mine in line with that. I am happy to change it to be in a folder. I believe if the statusline 'building' portion is called init.lua and the components place in a file called components.lua putting them in a directory should not break anything elsewhere in the code, but I have not tested that yet so I am not certain.