### PR TITLE
Add/Remove/Overwrite individual keys in NvChad setups

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -247,14 +247,17 @@ end
 --        if 3rd arg not given, then return "require('plugins.configs.telescope')"
 -- if override is a table, mark set the override flag for the default config to true
 -- override flag being true tells the plugin to call tbl_override_req as part of configuration
+
 M.override_req = function(name, default_config, config_function)
    local override, apply_table_override =
       require("core.utils").load_config().plugins.default_plugin_config_replace[name], "false"
    local result = default_config
    if type(override) == "string" and override ~= "" then
-      result = override
+      return "require('" .. override .. "')"
    elseif type(override) == "table" then
       apply_table_override = "true"
+   elseif type(override) == "function" then
+      return override
    end
 
    result = "('" .. result .. "')"

--- a/lua/plugins/configs/bufferline.lua
+++ b/lua/plugins/configs/bufferline.lua
@@ -5,7 +5,9 @@ if not present then
    return
 end
 
-bufferline.setup {
+local M = {}
+
+local chad_defaults = {
    options = {
       offsets = { { filetype = "NvimTree", text = "", padding = 1 } },
       buffer_close_icon = "",
@@ -135,3 +137,12 @@ bufferline.setup {
       },
    },
 }
+
+M.setup = function(override_flag)
+   if override_flag then
+      chad_defaults = require("core.utils").tbl_override_req("bufferline", chad_defaults)
+   end
+   bufferline.setup(chad_defaults)
+end
+
+return M

--- a/lua/plugins/configs/bufferline.lua
+++ b/lua/plugins/configs/bufferline.lua
@@ -1,13 +1,12 @@
-local colors = require("colors").get()
-
 local present, bufferline = pcall(require, "bufferline")
 if not present then
    return
 end
 
-local M = {}
-
-local chad_defaults = {
+local default = {
+   colors = require("colors").get(),
+}
+default = {
    options = {
       offsets = { { filetype = "NvimTree", text = "", padding = 1 } },
       buffer_close_icon = "",
@@ -47,102 +46,103 @@ local chad_defaults = {
 
    highlights = {
       background = {
-         guifg = colors.grey_fg,
-         guibg = colors.black2,
+         guifg = default.colors.grey_fg,
+         guibg = default.colors.black2,
       },
 
       -- buffers
       buffer_selected = {
-         guifg = colors.white,
-         guibg = colors.black,
+         guifg = default.colors.white,
+         guibg = default.colors.black,
          gui = "bold",
       },
       buffer_visible = {
-         guifg = colors.light_grey,
-         guibg = colors.black2,
+         guifg = default.colors.light_grey,
+         guibg = default.colors.black2,
       },
 
       -- for diagnostics = "nvim_lsp"
       error = {
-         guifg = colors.light_grey,
-         guibg = colors.black2,
+         guifg = default.colors.light_grey,
+         guibg = default.colors.black2,
       },
       error_diagnostic = {
-         guifg = colors.light_grey,
-         guibg = colors.black2,
+         guifg = default.colors.light_grey,
+         guibg = default.colors.black2,
       },
 
       -- close buttons
       close_button = {
-         guifg = colors.light_grey,
-         guibg = colors.black2,
+         guifg = default.colors.light_grey,
+         guibg = default.colors.black2,
       },
       close_button_visible = {
-         guifg = colors.light_grey,
-         guibg = colors.black2,
+         guifg = default.colors.light_grey,
+         guibg = default.colors.black2,
       },
       close_button_selected = {
-         guifg = colors.red,
-         guibg = colors.black,
+         guifg = default.colors.red,
+         guibg = default.colors.black,
       },
       fill = {
-         guifg = colors.grey_fg,
-         guibg = colors.black2,
+         guifg = default.colors.grey_fg,
+         guibg = default.colors.black2,
       },
       indicator_selected = {
-         guifg = colors.black,
-         guibg = colors.black,
+         guifg = default.colors.black,
+         guibg = default.colors.black,
       },
 
       -- modified
       modified = {
-         guifg = colors.red,
-         guibg = colors.black2,
+         guifg = default.colors.red,
+         guibg = default.colors.black2,
       },
       modified_visible = {
-         guifg = colors.red,
-         guibg = colors.black2,
+         guifg = default.colors.red,
+         guibg = default.colors.black2,
       },
       modified_selected = {
-         guifg = colors.green,
-         guibg = colors.black,
+         guifg = default.colors.green,
+         guibg = default.colors.black,
       },
 
       -- separators
       separator = {
-         guifg = colors.black2,
-         guibg = colors.black2,
+         guifg = default.colors.black2,
+         guibg = default.colors.black2,
       },
       separator_visible = {
-         guifg = colors.black2,
-         guibg = colors.black2,
+         guifg = default.colors.black2,
+         guibg = default.colors.black2,
       },
       separator_selected = {
-         guifg = colors.black2,
-         guibg = colors.black2,
+         guifg = default.colors.black2,
+         guibg = default.colors.black2,
       },
 
       -- tabs
       tab = {
-         guifg = colors.light_grey,
-         guibg = colors.one_bg3,
+         guifg = default.colors.light_grey,
+         guibg = default.colors.one_bg3,
       },
       tab_selected = {
-         guifg = colors.black2,
-         guibg = colors.nord_blue,
+         guifg = default.colors.black2,
+         guibg = default.colors.nord_blue,
       },
       tab_close = {
-         guifg = colors.red,
-         guibg = colors.black,
+         guifg = default.colors.red,
+         guibg = default.colors.black,
       },
    },
 }
 
+local M = {}
 M.setup = function(override_flag)
    if override_flag then
-      chad_defaults = require("core.utils").tbl_override_req("bufferline", chad_defaults)
+      default = require("core.utils").tbl_override_req("bufferline", default)
    end
-   bufferline.setup(chad_defaults)
+   bufferline.setup(default)
 end
 
 return M

--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -4,11 +4,9 @@ if not present then
    return
 end
 
-local M = {}
-
 vim.opt.completeopt = "menuone,noselect"
 
-local chad_defaults = {
+local default = {
    snippet = {
       expand = function(args)
          require("luasnip").lsp_expand(args.body)
@@ -67,11 +65,12 @@ local chad_defaults = {
    },
 }
 
-M.setup = function (override_flag)
+local M = {}
+M.setup = function(override_flag)
    if override_flag then
-      chad_defaults = require("core.utils").tbl_override_req("nvim_cmp", chad_defaults)
+      default = require("core.utils").tbl_override_req("nvim_cmp", default)
    end
-   cmp.setup(chad_defaults)
+   cmp.setup(default)
 end
 
 return M

--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -4,9 +4,11 @@ if not present then
    return
 end
 
+local M = {}
+
 vim.opt.completeopt = "menuone,noselect"
 
-cmp.setup {
+local chad_defaults = {
    snippet = {
       expand = function(args)
          require("luasnip").lsp_expand(args.body)
@@ -64,3 +66,12 @@ cmp.setup {
       { name = "path" },
    },
 }
+
+M.setup = function (override_flag)
+   if override_flag then
+      chad_defaults = require("core.utils").tbl_override_req("nvim_cmp", chad_defaults)
+   end
+   cmp.setup(chad_defaults)
+end
+
+return M

--- a/lua/plugins/configs/icons.lua
+++ b/lua/plugins/configs/icons.lua
@@ -3,9 +3,11 @@ if not present then
    return
 end
 
+local M = {}
+
 local colors = require("colors").get()
 
-icons.setup {
+local chad_defaults = {
    override = {
       c = {
          icon = "",
@@ -142,5 +144,15 @@ icons.setup {
          color = colors.sun,
          name = "zip",
       },
-   },
+   }
 }
+
+
+M.setup = function(override_flag)
+   if override_flag then
+      chad_defaults = require("core.utils").tbl_override_req("nvim_web_devicons", chad_defaults)
+   end
+   icons.setup(chad_defaults)
+end
+
+return M

--- a/lua/plugins/configs/icons.lua
+++ b/lua/plugins/configs/icons.lua
@@ -3,156 +3,156 @@ if not present then
    return
 end
 
-local M = {}
+local default = {
+   colors = require("colors").get(),
+}
 
-local colors = require("colors").get()
-
-local chad_defaults = {
+default = {
    override = {
       c = {
          icon = "",
-         color = colors.blue,
+         color = default.colors.blue,
          name = "c",
       },
       css = {
          icon = "",
-         color = colors.blue,
+         color = default.colors.blue,
          name = "css",
       },
       deb = {
          icon = "",
-         color = colors.cyan,
+         color = default.colors.cyan,
          name = "deb",
       },
       Dockerfile = {
          icon = "",
-         color = colors.cyan,
+         color = default.colors.cyan,
          name = "Dockerfile",
       },
       html = {
          icon = "",
-         color = colors.baby_pink,
+         color = default.colors.baby_pink,
          name = "html",
       },
       jpeg = {
          icon = "",
-         color = colors.dark_purple,
+         color = default.colors.dark_purple,
          name = "jpeg",
       },
       jpg = {
          icon = "",
-         color = colors.dark_purple,
+         color = default.colors.dark_purple,
          name = "jpg",
       },
       js = {
          icon = "",
-         color = colors.sun,
+         color = default.colors.sun,
          name = "js",
       },
       kt = {
          icon = "󱈙",
-         color = colors.orange,
+         color = default.colors.orange,
          name = "kt",
       },
       lock = {
          icon = "",
-         color = colors.red,
+         color = default.colors.red,
          name = "lock",
       },
       lua = {
          icon = "",
-         color = colors.blue,
+         color = default.colors.blue,
          name = "lua",
       },
       mp3 = {
          icon = "",
-         color = colors.white,
+         color = default.colors.white,
          name = "mp3",
       },
       mp4 = {
          icon = "",
-         color = colors.white,
+         color = default.colors.white,
          name = "mp4",
       },
       out = {
          icon = "",
-         color = colors.white,
+         color = default.colors.white,
          name = "out",
       },
       png = {
          icon = "",
-         color = colors.dark_purple,
+         color = default.colors.dark_purple,
          name = "png",
       },
       py = {
          icon = "",
-         color = colors.cyan,
+         color = default.colors.cyan,
          name = "py",
       },
       ["robots.txt"] = {
          icon = "ﮧ",
-         color = colors.red,
+         color = default.colors.red,
          name = "robots",
       },
       toml = {
          icon = "",
-         color = colors.blue,
+         color = default.colors.blue,
          name = "toml",
       },
       ts = {
          icon = "ﯤ",
-         color = colors.teal,
+         color = default.colors.teal,
          name = "ts",
       },
       ttf = {
          icon = "",
-         color = colors.white,
+         color = default.colors.white,
          name = "TrueTypeFont",
       },
       rb = {
          icon = "",
-         color = colors.pink,
+         color = default.colors.pink,
          name = "rb",
       },
       rpm = {
          icon = "",
-         color = colors.orange,
+         color = default.colors.orange,
          name = "rpm",
       },
       vue = {
          icon = "﵂",
-         color = colors.vibrant_green,
+         color = default.colors.vibrant_green,
          name = "vue",
       },
       woff = {
          icon = "",
-         color = colors.white,
+         color = default.colors.white,
          name = "WebOpenFontFormat",
       },
       woff2 = {
          icon = "",
-         color = colors.white,
+         color = default.colors.white,
          name = "WebOpenFontFormat2",
       },
       xz = {
          icon = "",
-         color = colors.sun,
+         color = default.colors.sun,
          name = "xz",
       },
       zip = {
          icon = "",
-         color = colors.sun,
+         color = default.colors.sun,
          name = "zip",
       },
-   }
+   },
 }
 
-
+local M = {}
 M.setup = function(override_flag)
    if override_flag then
-      chad_defaults = require("core.utils").tbl_override_req("nvim_web_devicons", chad_defaults)
+      default = require("core.utils").tbl_override_req("nvim_web_devicons", default)
    end
-   icons.setup(chad_defaults)
+   icons.setup(default)
 end
 
 return M

--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -1,18 +1,20 @@
 local present, nvimtree = pcall(require, "nvim-tree")
-
-local conf = require("core.utils").load_config().plugins.options.nvimtree
-
-local git_status = conf.enable_git
-local ui = conf.ui
-
 if not present then
    return
 end
 
 local g = vim.g
+local default = {
+   conf = require("core.utils").load_config().plugins.options.nvimtree,
+}
+
+default = {
+   git_status = default.conf.enable_git,
+   ui = default.conf.ui,
+}
 
 g.nvim_tree_add_trailing = 0 -- append a trailing slash to folder names
-g.nvim_tree_git_hl = git_status
+g.nvim_tree_git_hl = default.git_status
 g.nvim_tree_highlight_opened_files = 0
 g.nvim_tree_indent_markers = 1
 g.nvim_tree_quit_on_open = 0 -- closes tree when file's opened
@@ -26,7 +28,7 @@ g.nvim_tree_window_picker_exclude = {
 g.nvim_tree_show_icons = {
    folders = 1,
    files = 1,
-   git = git_status,
+   git = default.git_status,
 }
 
 g.nvim_tree_icons = {
@@ -51,7 +53,7 @@ g.nvim_tree_icons = {
    },
 }
 
-local chad_defaults = {
+default = {
    filters = {
       dotfiles = false,
    },
@@ -66,17 +68,18 @@ local chad_defaults = {
       enable = true,
       update_cwd = false,
    },
-   view = ui,
+   view = default.ui,
    git = {
       ignore = false,
    },
 }
 
-M.setup = function (override_flag)
+local M = {}
+M.setup = function(override_flag)
    if override_flag then
-      chad_defaults = require("core.utils").tbl_override_req("nvim_tree", chad_defaults)
+      default = require("core.utils").tbl_override_req("nvim_tree", default)
    end
-   nvimtree.setup(chad_defaults)
+   nvimtree.setup(default)
 end
 
 return M

--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -51,7 +51,7 @@ g.nvim_tree_icons = {
    },
 }
 
-nvimtree.setup {
+local chad_defaults = {
    filters = {
       dotfiles = false,
    },
@@ -71,3 +71,12 @@ nvimtree.setup {
       ignore = false,
    },
 }
+
+M.setup = function (override_flag)
+   if override_flag then
+      chad_defaults = require("core.utils").tbl_override_req("nvim_tree", chad_defaults)
+   end
+   nvimtree.setup(chad_defaults)
+end
+
+return M

--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -7,11 +7,11 @@ M.autopairs = function(override_flag)
    local present2, cmp_autopairs = pcall(require, "nvim-autopairs.completion.cmp")
 
    if present1 and present2 then
-      local chad_defaults = {fast_wrap = {}}
+      local default = { fast_wrap = {} }
       if override_flag then
-         chad_defaults = require("core.utils").tbl_override_req("nvim_autopairs", chad_defaults)
+         default = require("core.utils").tbl_override_req("nvim_autopairs", default)
       end
-      autopairs.setup(chad_defaults)
+      autopairs.setup(default)
 
       local cmp = require "cmp"
       cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done())
@@ -26,7 +26,7 @@ M.better_escape = function()
 end
 
 M.blankline = function(override_flag)
-   local chad_defaults = {
+   local default = {
       indentLine_enabled = 1,
       char = "▏",
       filetype_exclude = {
@@ -45,17 +45,17 @@ M.blankline = function(override_flag)
       show_first_indent_level = false,
    }
    if override_flag then
-      chad_defaults = require("core.utils").tbl_override_req("indent_blankline", chad_defaults)
+      default = require("core.utils").tbl_override_req("indent_blankline", default)
    end
-   require("indent_blankline").setup(chad_defaults)
+   require("indent_blankline").setup(default)
 end
 
 M.colorizer = function(override_flag)
    local present, colorizer = pcall(require, "colorizer")
    if present then
-      local chad_defaults = {
+      local default = {
          filetypes = {
-            "*"
+            "*",
          },
          user_default_options = {
             RGB = true, -- #RGB hex codes
@@ -72,9 +72,9 @@ M.colorizer = function(override_flag)
          },
       }
       if override_flag then
-         chad_defaults = require("core.utils").tbl_override_req("nvim_colorizer", chad_defaults)
+         default = require("core.utils").tbl_override_req("nvim_colorizer", default)
       end
-      colorizer.setup(chad_defaults["filetypes"], chad_defaults["user_default_options"])
+      colorizer.setup(default["filetypes"], default["user_default_options"])
       vim.cmd "ColorizerReloadAllBuffers"
    end
 end
@@ -82,25 +82,25 @@ end
 M.comment = function(override_flag)
    local present, nvim_comment = pcall(require, "Comment")
    if present then
-      local chad_defaults = {}
+      local default = {}
       if override_flag then
-         chad_defaults = require("core.utils").tbl_override_req("nvim_comment", chad_defaults)
+         default = require("core.utils").tbl_override_req("nvim_comment", default)
       end
-      nvim_comment.setup(chad_defaults)
+      nvim_comment.setup(default)
    end
 end
 
 M.luasnip = function(override_flag)
    local present, luasnip = pcall(require, "luasnip")
    if present then
-      local chad_defaults = {
+      local default = {
          history = true,
          updateevents = "TextChanged,TextChangedI",
       }
       if override_flag then
-         chad_defaults = require("core.utils").tbl_override_req("luasnip", chad_defaults)
+         default = require("core.utils").tbl_override_req("luasnip", default)
       end
-      luasnip.config.set_config(chad_defaults)
+      luasnip.config.set_config(default)
       require("luasnip/loaders/from_vscode").load { paths = chadrc_config.plugins.options.luasnip.snippet_path }
       require("luasnip/loaders/from_vscode").load()
    end
@@ -109,7 +109,7 @@ end
 M.signature = function(override_flag)
    local present, lspsignature = pcall(require, "lsp_signature")
    if present then
-      local chad_defaults = {
+      local default = {
          bind = true,
          doc_lines = 0,
          floating_window = true,
@@ -127,9 +127,9 @@ M.signature = function(override_flag)
          padding = "", -- character to pad on left and right of signature can be ' ', or '|'  etc
       }
       if override_flag then
-         chad_defaults = require("core.utils").tbl_override_req("signature", chad_defaults)
+         default = require("core.utils").tbl_override_req("signature", default)
       end
-      lspsignature.setup(chad_defaults)
+      lspsignature.setup(default)
    end
 end
 
@@ -176,7 +176,7 @@ end
 M.gitsigns = function(override_flag)
    local present, gitsigns = pcall(require, "gitsigns")
    if present then
-      local chad_defaults = {
+      local default = {
          signs = {
             add = { hl = "DiffAdd", text = "│", numhl = "GitSignsAddNr" },
             change = { hl = "DiffChange", text = "│", numhl = "GitSignsChangeNr" },
@@ -186,9 +186,9 @@ M.gitsigns = function(override_flag)
          },
       }
       if override_flag then
-         chad_defaults = require("core.utils").tbl_override_req("gitsigns", chad_defaults)
+         default = require("core.utils").tbl_override_req("gitsigns", default)
       end
-      gitsigns.setup(chad_defaults)
+      gitsigns.setup(default)
    end
 end
 

--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -2,12 +2,16 @@ local M = {}
 
 local chadrc_config = require("core.utils").load_config()
 
-M.autopairs = function()
+M.autopairs = function(override_flag)
    local present1, autopairs = pcall(require, "nvim-autopairs")
    local present2, cmp_autopairs = pcall(require, "nvim-autopairs.completion.cmp")
 
    if present1 and present2 then
-      autopairs.setup({fast_wrap = {}})
+      local chad_defaults = {fast_wrap = {}}
+      if override_flag then
+         chad_defaults = require("core.utils").tbl_override_req("nvim_autopairs", chad_defaults)
+      end
+      autopairs.setup(chad_defaults)
 
       local cmp = require "cmp"
       cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done())
@@ -21,8 +25,8 @@ M.better_escape = function()
    }
 end
 
-M.blankline = function()
-   require("indent_blankline").setup {
+M.blankline = function(override_flag)
+   local chad_defaults = {
       indentLine_enabled = 1,
       char = "▏",
       filetype_exclude = {
@@ -40,52 +44,72 @@ M.blankline = function()
       show_trailing_blankline_indent = false,
       show_first_indent_level = false,
    }
+   if override_flag then
+      chad_defaults = require("core.utils").tbl_override_req("indent_blankline", chad_defaults)
+   end
+   require("indent_blankline").setup(chad_defaults)
 end
 
-M.colorizer = function()
+M.colorizer = function(override_flag)
    local present, colorizer = pcall(require, "colorizer")
    if present then
-      colorizer.setup({ "*" }, {
-         RGB = true, -- #RGB hex codes
-         RRGGBB = true, -- #RRGGBB hex codes
-         names = false, -- "Name" codes like Blue
-         RRGGBBAA = false, -- #RRGGBBAA hex codes
-         rgb_fn = false, -- CSS rgb() and rgba() functions
-         hsl_fn = false, -- CSS hsl() and hsla() functions
-         css = false, -- Enable all CSS features: rgb_fn, hsl_fn, names, RGB, RRGGBB
-         css_fn = false, -- Enable all CSS *functions*: rgb_fn, hsl_fn
+      local chad_defaults = {
+         filetypes = {
+            "*"
+         },
+         user_default_options = {
+            RGB = true, -- #RGB hex codes
+            RRGGBB = true, -- #RRGGBB hex codes
+            names = false, -- "Name" codes like Blue
+            RRGGBBAA = false, -- #RRGGBBAA hex codes
+            rgb_fn = false, -- CSS rgb() and rgba() functions
+            hsl_fn = false, -- CSS hsl() and hsla() functions
+            css = false, -- Enable all CSS features: rgb_fn, hsl_fn, names, RGB, RRGGBB
+            css_fn = false, -- Enable all CSS *functions*: rgb_fn, hsl_fn
 
-         -- Available modes: foreground, background
-         mode = "background", -- Set the display mode.
-      })
+            -- Available modes: foreground, background
+            mode = "background", -- Set the display mode.
+         },
+      }
+      if override_flag then
+         chad_defaults = require("core.utils").tbl_override_req("nvim_colorizer", chad_defaults)
+      end
+      colorizer.setup(chad_defaults["filetypes"], chad_defaults["user_default_options"])
       vim.cmd "ColorizerReloadAllBuffers"
    end
 end
 
-M.comment = function()
+M.comment = function(override_flag)
    local present, nvim_comment = pcall(require, "Comment")
    if present then
-      nvim_comment.setup()
+      local chad_defaults = {}
+      if override_flag then
+         chad_defaults = require("core.utils").tbl_override_req("nvim_comment", chad_defaults)
+      end
+      nvim_comment.setup(chad_defaults)
    end
 end
 
-M.luasnip = function()
+M.luasnip = function(override_flag)
    local present, luasnip = pcall(require, "luasnip")
    if present then
-      luasnip.config.set_config {
+      local chad_defaults = {
          history = true,
          updateevents = "TextChanged,TextChangedI",
       }
-
+      if override_flag then
+         chad_defaults = require("core.utils").tbl_override_req("luasnip", chad_defaults)
+      end
+      luasnip.config.set_config(chad_defaults)
       require("luasnip/loaders/from_vscode").load { paths = chadrc_config.plugins.options.luasnip.snippet_path }
       require("luasnip/loaders/from_vscode").load()
    end
 end
 
-M.signature = function()
+M.signature = function(override_flag)
    local present, lspsignature = pcall(require, "lsp_signature")
    if present then
-      lspsignature.setup {
+      local chad_defaults = {
          bind = true,
          doc_lines = 0,
          floating_window = true,
@@ -102,6 +126,10 @@ M.signature = function()
          zindex = 200, -- by default it will be on top of all floating windows, set to 50 send it to bottom
          padding = "", -- character to pad on left and right of signature can be ' ', or '|'  etc
       }
+      if override_flag then
+         chad_defaults = require("core.utils").tbl_override_req("signature", chad_defaults)
+      end
+      lspsignature.setup(chad_defaults)
    end
 end
 
@@ -145,10 +173,10 @@ M.lsp_handlers = function()
    end
 end
 
-M.gitsigns = function()
+M.gitsigns = function(override_flag)
    local present, gitsigns = pcall(require, "gitsigns")
    if present then
-      gitsigns.setup {
+      local chad_defaults = {
          signs = {
             add = { hl = "DiffAdd", text = "│", numhl = "GitSignsAddNr" },
             change = { hl = "DiffChange", text = "│", numhl = "GitSignsChangeNr" },
@@ -157,6 +185,10 @@ M.gitsigns = function()
             changedelete = { hl = "DiffChangeDelete", text = "~", numhl = "GitSignsChangeNr" },
          },
       }
+      if override_flag then
+         chad_defaults = require("core.utils").tbl_override_req("gitsigns", chad_defaults)
+      end
+      gitsigns.setup(chad_defaults)
    end
 end
 

--- a/lua/plugins/configs/statusline.lua
+++ b/lua/plugins/configs/statusline.lua
@@ -1,8 +1,16 @@
- local colors = require("colors").get()
-local lsp = require "feline.providers.lsp"
-local lsp_severity = vim.diagnostic.severity
+local present, feline = pcall(require, "feline")
+if not present then
+   return
+end
 
-local icon_styles = {
+local default = {
+   colors = require("colors").get(),
+   lsp = require "feline.providers.lsp",
+   lsp_severity = vim.diagnostic.severity,
+   config = require("core.utils").load_config().plugins.options.statusline,
+}
+
+default.icon_styles = {
    default = {
       left = "",
       right = " ",
@@ -43,35 +51,35 @@ local icon_styles = {
    },
 }
 
-local config = require("core.utils").load_config().plugins.options.statusline
-
 -- statusline style
-local user_statusline_style = config.style
-local statusline_style = icon_styles[user_statusline_style]
+default.statusline_style = default.icon_styles[default.config.style]
 
 -- show short statusline on small screens
-local shortline = config.shortline == false and true
+default.shortline = default.config.shortline == false and true
 
 -- Initialize the components table
-local components = {
+default.components = {
    active = {},
 }
 
-local main_icon = {
-   provider = statusline_style.main_icon,
+default.main_icon = {
+   provider = default.statusline_style.main_icon,
 
    hl = {
-      fg = colors.statusline_bg,
-      bg = colors.nord_blue,
+      fg = default.colors.statusline_bg,
+      bg = default.colors.nord_blue,
    },
 
-   right_sep = { str = statusline_style.right, hl = {
-      fg = colors.nord_blue,
-      bg = colors.lightbg,
-   } },
+   right_sep = {
+      str = default.statusline_style.right,
+      hl = {
+         fg = default.colors.nord_blue,
+         bg = default.colors.lightbg,
+      },
+   },
 }
 
-local file_name = {
+default.file_name = {
    provider = function()
       local filename = vim.fn.expand "%:t"
       local extension = vim.fn.expand "%:e"
@@ -82,46 +90,49 @@ local file_name = {
       end
       return " " .. icon .. " " .. filename .. " "
    end,
-   enabled = shortline or function(winid)
+   enabled = default.shortline or function(winid)
       return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
    end,
    hl = {
-      fg = colors.white,
-      bg = colors.lightbg,
+      fg = default.colors.white,
+      bg = default.colors.lightbg,
    },
 
-   right_sep = { str = statusline_style.right, hl = { fg = colors.lightbg, bg = colors.lightbg2 } },
+   right_sep = {
+      str = default.statusline_style.right,
+      hl = { fg = default.colors.lightbg, bg = default.colors.lightbg2 },
+   },
 }
 
-local dir_name = {
+default.dir_name = {
    provider = function()
       local dir_name = vim.fn.fnamemodify(vim.fn.getcwd(), ":t")
       return "  " .. dir_name .. " "
    end,
 
-   enabled = shortline or function(winid)
+   enabled = default.shortline or function(winid)
       return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
    end,
 
    hl = {
-      fg = colors.grey_fg2,
-      bg = colors.lightbg2,
+      fg = default.colors.grey_fg2,
+      bg = default.colors.lightbg2,
    },
    right_sep = {
-      str = statusline_style.right,
+      str = default.statusline_style.right,
       hi = {
-         fg = colors.lightbg2,
-         bg = colors.statusline_bg,
+         fg = default.colors.lightbg2,
+         bg = default.colors.statusline_bg,
       },
    },
 }
 
-local diff = {
+default.diff = {
    add = {
       provider = "git_diff_added",
       hl = {
-         fg = colors.grey_fg2,
-         bg = colors.statusline_bg,
+         fg = default.colors.grey_fg2,
+         bg = default.colors.statusline_bg,
       },
       icon = " ",
    },
@@ -129,8 +140,8 @@ local diff = {
    change = {
       provider = "git_diff_changed",
       hl = {
-         fg = colors.grey_fg2,
-         bg = colors.statusline_bg,
+         fg = default.colors.grey_fg2,
+         bg = default.colors.statusline_bg,
       },
       icon = "   ",
    },
@@ -138,65 +149,65 @@ local diff = {
    remove = {
       provider = "git_diff_removed",
       hl = {
-         fg = colors.grey_fg2,
-         bg = colors.statusline_bg,
+         fg = default.colors.grey_fg2,
+         bg = default.colors.statusline_bg,
       },
       icon = "  ",
    },
 }
 
-local git_branch = {
+default.git_branch = {
    provider = "git_branch",
-   enabled = shortline or function(winid)
+   enabled = default.shortline or function(winid)
       return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
    end,
    hl = {
-      fg = colors.grey_fg2,
-      bg = colors.statusline_bg,
+      fg = default.colors.grey_fg2,
+      bg = default.colors.statusline_bg,
    },
    icon = "  ",
 }
 
-local diagnostic = {
+default.diagnostic = {
    errors = {
       provider = "diagnostic_errors",
       enabled = function()
-         return lsp.diagnostics_exist(lsp_severity.ERROR)
+         return default.lsp.diagnostics_exist(default.lsp_severity.ERROR)
       end,
 
-      hl = { fg = colors.red },
+      hl = { fg = default.colors.red },
       icon = "  ",
    },
 
    warning = {
       provider = "diagnostic_warnings",
       enabled = function()
-         return lsp.diagnostics_exist(lsp_severity.WARN)
+         return default.lsp.diagnostics_exist(default.lsp_severity.WARN)
       end,
-      hl = { fg = colors.yellow },
+      hl = { fg = default.colors.yellow },
       icon = "  ",
    },
 
    hint = {
       provider = "diagnostic_hints",
       enabled = function()
-         return lsp.diagnostics_exist(lsp_severity.HINT)
+         return default.lsp.diagnostics_exist(default.lsp_severity.HINT)
       end,
-      hl = { fg = colors.grey_fg2 },
+      hl = { fg = default.colors.grey_fg2 },
       icon = "  ",
    },
 
    info = {
       provider = "diagnostic_info",
       enabled = function()
-         return lsp.diagnostics_exist(lsp_severity.INFO)
+         return default.lsp.diagnostics_exist(default.lsp_severity.INFO)
       end,
-      hl = { fg = colors.green },
+      hl = { fg = default.colors.green },
       icon = "  ",
    },
 }
 
-local lsp_progress = {
+default.lsp_progress = {
    provider = function()
       local Lsp = vim.lsp.util.get_progress_messages()[1]
 
@@ -228,13 +239,13 @@ local lsp_progress = {
 
       return ""
    end,
-   enabled = shortline or function(winid)
+   enabled = default.shortline or function(winid)
       return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 80
    end,
-   hl = { fg = colors.green },
+   hl = { fg = default.colors.green },
 }
 
-local lsp_icon = {
+default.lsp_icon = {
    provider = function()
       if next(vim.lsp.buf_get_clients()) ~= nil then
          return "  LSP"
@@ -242,112 +253,112 @@ local lsp_icon = {
          return ""
       end
    end,
-   enabled = shortline or function(winid)
+   enabled = default.shortline or function(winid)
       return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 70
    end,
-   hl = { fg = colors.grey_fg2, bg = colors.statusline_bg },
+   hl = { fg = default.colors.grey_fg2, bg = default.colors.statusline_bg },
 }
 
-local mode_colors = {
-   ["n"] = { "NORMAL", colors.red },
-   ["no"] = { "N-PENDING", colors.red },
-   ["i"] = { "INSERT", colors.dark_purple },
-   ["ic"] = { "INSERT", colors.dark_purple },
-   ["t"] = { "TERMINAL", colors.green },
-   ["v"] = { "VISUAL", colors.cyan },
-   ["V"] = { "V-LINE", colors.cyan },
-   [""] = { "V-BLOCK", colors.cyan },
-   ["R"] = { "REPLACE", colors.orange },
-   ["Rv"] = { "V-REPLACE", colors.orange },
-   ["s"] = { "SELECT", colors.nord_blue },
-   ["S"] = { "S-LINE", colors.nord_blue },
-   [""] = { "S-BLOCK", colors.nord_blue },
-   ["c"] = { "COMMAND", colors.pink },
-   ["cv"] = { "COMMAND", colors.pink },
-   ["ce"] = { "COMMAND", colors.pink },
-   ["r"] = { "PROMPT", colors.teal },
-   ["rm"] = { "MORE", colors.teal },
-   ["r?"] = { "CONFIRM", colors.teal },
-   ["!"] = { "SHELL", colors.green },
+default.mode_colors = {
+   ["n"] = { "NORMAL", default.colors.red },
+   ["no"] = { "N-PENDING", default.colors.red },
+   ["i"] = { "INSERT", default.colors.dark_purple },
+   ["ic"] = { "INSERT", default.colors.dark_purple },
+   ["t"] = { "TERMINAL", default.colors.green },
+   ["v"] = { "VISUAL", default.colors.cyan },
+   ["V"] = { "V-LINE", default.colors.cyan },
+   [""] = { "V-BLOCK", default.colors.cyan },
+   ["R"] = { "REPLACE", default.colors.orange },
+   ["Rv"] = { "V-REPLACE", default.colors.orange },
+   ["s"] = { "SELECT", default.colors.nord_blue },
+   ["S"] = { "S-LINE", default.colors.nord_blue },
+   [""] = { "S-BLOCK", default.colors.nord_blue },
+   ["c"] = { "COMMAND", default.colors.pink },
+   ["cv"] = { "COMMAND", default.colors.pink },
+   ["ce"] = { "COMMAND", default.colors.pink },
+   ["r"] = { "PROMPT", default.colors.teal },
+   ["rm"] = { "MORE", default.colors.teal },
+   ["r?"] = { "CONFIRM", default.colors.teal },
+   ["!"] = { "SHELL", default.colors.green },
 }
 
-local chad_mode_hl = function()
+default.chad_mode_hl = function()
    return {
-      fg = mode_colors[vim.fn.mode()][2],
-      bg = colors.one_bg,
+      fg = default.mode_colors[vim.fn.mode()][2],
+      bg = default.colors.one_bg,
    }
 end
 
-local empty_space = {
-   provider = " " .. statusline_style.left,
+default.empty_space = {
+   provider = " " .. default.statusline_style.left,
    hl = {
-      fg = colors.one_bg2,
-      bg = colors.statusline_bg,
+      fg = default.colors.one_bg2,
+      bg = default.colors.statusline_bg,
    },
 }
 
 -- this matches the vi mode color
-local empty_spaceColored = {
-   provider = statusline_style.left,
+default.empty_spaceColored = {
+   provider = default.statusline_style.left,
    hl = function()
       return {
-         fg = mode_colors[vim.fn.mode()][2],
-         bg = colors.one_bg2,
+         fg = default.mode_colors[vim.fn.mode()][2],
+         bg = default.colors.one_bg2,
       }
    end,
 }
 
-local mode_icon = {
-   provider = statusline_style.vi_mode_icon,
+default.mode_icon = {
+   provider = default.statusline_style.vi_mode_icon,
    hl = function()
       return {
-         fg = colors.statusline_bg,
-         bg = mode_colors[vim.fn.mode()][2],
+         fg = default.colors.statusline_bg,
+         bg = default.mode_colors[vim.fn.mode()][2],
       }
    end,
 }
 
-local empty_space2 = {
+default.empty_space2 = {
    provider = function()
-      return " " .. mode_colors[vim.fn.mode()][1] .. " "
+      return " " .. default.mode_colors[vim.fn.mode()][1] .. " "
    end,
-   hl = chad_mode_hl,
+   hl = default.chad_mode_hl,
 }
 
-local separator_right = {
-   provider = statusline_style.left,
-   enabled = shortline or function(winid)
+default.separator_right = {
+   provider = default.statusline_style.left,
+   enabled = default.shortline or function(winid)
       return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
    end,
    hl = {
-      fg = colors.grey,
-      bg = colors.one_bg,
+      fg = default.colors.grey,
+      bg = default.colors.one_bg,
    },
 }
 
-local separator_right2 = {
-   provider = statusline_style.left,
-   enabled = shortline or function(winid)
+default.separator_right2 = {
+   provider = default.statusline_style.left,
+   enabled = default.shortline or function(winid)
       return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
    end,
    hl = {
-      fg = colors.green,
-      bg = colors.grey,
+      fg = default.colors.green,
+      bg = default.colors.grey,
    },
 }
 
-local position_icon = {
-   provider = statusline_style.position_icon,
-   enabled = shortline or function(winid)
+default.position_icon = {
+   provider = default.statusline_style.position_icon,
+   enabled = default.shortline or function(winid)
       return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
    end,
    hl = {
-      fg = colors.black,
-      bg = colors.green,
+      fg = default.colors.black,
+      bg = default.colors.green,
    },
 }
 
-local current_line = {
+default.current_line = {
    provider = function()
       local current_line = vim.fn.line "."
       local total_line = vim.fn.line "$"
@@ -361,13 +372,13 @@ local current_line = {
       return " " .. result .. "%% "
    end,
 
-   enabled = shortline or function(winid)
+   enabled = default.shortline or function(winid)
       return vim.api.nvim_win_get_width(tonumber(winid) or 0) > 90
    end,
 
    hl = {
-      fg = colors.green,
-      bg = colors.one_bg,
+      fg = default.colors.green,
+      bg = default.colors.one_bg,
    },
 }
 
@@ -375,45 +386,53 @@ local function add_table(a, b)
    table.insert(a, b)
 end
 
--- components are divided in 3 sections
-local left = {}
-local middle = {}
-local right = {}
+local M = {}
+M.setup = function(override_flag)
+   if override_flag then
+      default = require("core.utils").tbl_override_req("feline", default)
+   end
+   -- components are divided in 3 sections
+   default.left = {}
+   default.middle = {}
+   default.right = {}
 
--- left
-add_table(left, main_icon)
-add_table(left, file_name)
-add_table(left, dir_name)
-add_table(left, diff.add)
-add_table(left, diff.change)
-add_table(left, diff.remove)
-add_table(left, diagnostic.error)
-add_table(left, diagnostic.warning)
-add_table(left, diagnostic.hint)
-add_table(left, diagnostic.info)
+   -- left
+   add_table(default.left, default.main_icon)
+   add_table(default.left, default.file_name)
+   add_table(default.left, default.dir_name)
+   add_table(default.left, default.diff.add)
+   add_table(default.left, default.diff.change)
+   add_table(default.left, default.diff.remove)
+   add_table(default.left, default.diagnostic.error)
+   add_table(default.left, default.diagnostic.warning)
+   add_table(default.left, default.diagnostic.hint)
+   add_table(default.left, default.diagnostic.info)
 
-add_table(middle, lsp_progress)
+   add_table(default.middle, default.lsp_progress)
 
--- right
-add_table(right, lsp_icon)
-add_table(right, git_branch)
-add_table(right, empty_space)
-add_table(right, empty_spaceColored)
-add_table(right, mode_icon)
-add_table(right, empty_space2)
-add_table(right, separator_right)
-add_table(right, separator_right2)
-add_table(right, position_icon)
-add_table(right, current_line)
+   -- right
+   add_table(default.right, default.lsp_icon)
+   add_table(default.right, default.git_branch)
+   add_table(default.right, default.empty_space)
+   add_table(default.right, default.empty_spaceColored)
+   add_table(default.right, default.mode_icon)
+   add_table(default.right, default.empty_space2)
+   add_table(default.right, default.separator_right)
+   add_table(default.right, default.separator_right2)
+   add_table(default.right, default.position_icon)
+   add_table(default.right, default.current_line)
 
-components.active[1] = left
-components.active[2] = middle
-components.active[3] = right
+   default.components.active[1] = default.left
+   default.components.active[2] = default.middle
+   default.components.active[3] = default.right
 
-require("feline").setup {
-   theme = {
-      bg = colors.statusline_bg,
-      fg = colors.fg,
-   },
-   components = components,
-}
+   feline.setup {
+      theme = {
+         bg = default.colors.statusline_bg,
+         fg = default.colors.fg,
+      },
+      components = default.components,
+   }
+end
+
+return M

--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -4,9 +4,7 @@ if not present then
    return
 end
 
-local M = {}
-
-local chad_defaults = {
+local default = {
    defaults = {
       vimgrep_arguments = {
          "rg",
@@ -55,12 +53,13 @@ local chad_defaults = {
    },
 }
 
-function M.setup(override_flag)
+local M = {}
+M.setup = function(override_flag)
    if override_flag then
-      chad_defaults = require("core.utils").tbl_override_req("telescope", chad_defaults)
+      default = require("core.utils").tbl_override_req("telescope", default)
    end
 
-   telescope.setup(chad_defaults)
+   telescope.setup(default)
 
    local extensions = { "themes", "terms" }
 

--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -4,7 +4,9 @@ if not present then
    return
 end
 
-telescope.setup {
+local M = {}
+
+local chad_defaults = {
    defaults = {
       vimgrep_arguments = {
          "rg",
@@ -53,10 +55,20 @@ telescope.setup {
    },
 }
 
-local extensions = { "themes", "terms" }
-
-pcall(function()
-   for _, ext in ipairs(extensions) do
-      telescope.load_extension(ext)
+function M.setup(override_flag)
+   if override_flag then
+      chad_defaults = require("core.utils").tbl_override_req("telescope", chad_defaults)
    end
-end)
+
+   telescope.setup(chad_defaults)
+
+   local extensions = { "themes", "terms" }
+
+   pcall(function()
+      for _, ext in ipairs(extensions) do
+         telescope.load_extension(ext)
+      end
+   end)
+end
+
+return M

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -4,7 +4,9 @@ if not present then
    return
 end
 
-ts_config.setup {
+local M = {}
+
+local chad_defaults = {
    ensure_installed = {
       "lua",
       "vim",
@@ -14,3 +16,12 @@ ts_config.setup {
       use_languagetree = true,
    },
 }
+
+M.setup = function (override_flag)
+   if override_flag then
+      chad_defaults = require("core.utils").tbl_override_req("nvim_treesitter", chad_defaults)
+   end
+   ts_config.setup(chad_defaults)
+end
+
+return M

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -4,9 +4,7 @@ if not present then
    return
 end
 
-local M = {}
-
-local chad_defaults = {
+local default = {
    ensure_installed = {
       "lua",
       "vim",
@@ -17,11 +15,12 @@ local chad_defaults = {
    },
 }
 
-M.setup = function (override_flag)
+local M = {}
+M.setup = function(override_flag)
    if override_flag then
-      chad_defaults = require("core.utils").tbl_override_req("nvim_treesitter", chad_defaults)
+      default = require("core.utils").tbl_override_req("nvim_treesitter", default)
    end
-   ts_config.setup(chad_defaults)
+   ts_config.setup(default)
 end
 
 return M

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -32,7 +32,7 @@ return packer.startup(function()
    use {
       "kyazdani42/nvim-web-devicons",
       after = "nvim-base16.lua",
-      config = override_req("nvim_web_devicons", "plugins.configs.icons"),
+      config = override_req("nvim_web_devicons", "(plugins.configs.icons).setup()"),
    }
 
    use {
@@ -46,7 +46,7 @@ return packer.startup(function()
       "akinsho/bufferline.nvim",
       disable = not plugin_settings.status.bufferline,
       after = "nvim-web-devicons",
-      config = override_req("bufferline", "plugins.configs.bufferline"),
+      config = override_req("bufferline", "(plugins.configs.bufferline).setup()"),
       setup = function()
          require("core.mappings").bufferline()
       end,
@@ -69,7 +69,7 @@ return packer.startup(function()
    use {
       "nvim-treesitter/nvim-treesitter",
       event = "BufRead",
-      config = override_req("nvim_treesitter", "plugins.configs.treesitter"),
+      config = override_req("nvim_treesitter", "(plugins.configs.treesitter).setup()"),
    }
 
    -- git stuff
@@ -133,7 +133,7 @@ return packer.startup(function()
       "hrsh7th/nvim-cmp",
       disable = not plugin_settings.status.cmp,
       after = plugin_settings.options.cmp.lazy_load and "friendly-snippets",
-      config = override_req("nvim_cmp", "plugins.configs.cmp"),
+      config = override_req("nvim_cmp", "(plugins.configs.cmp).setup()"),
    }
 
    use {
@@ -207,7 +207,7 @@ return packer.startup(function()
       -- only set "after" if lazy load is disabled and vice versa for "cmd"
       after = not plugin_settings.options.nvimtree.lazy_load and "nvim-web-devicons",
       cmd = plugin_settings.options.nvimtree.lazy_load and { "NvimTreeToggle", "NvimTreeFocus" },
-      config = override_req("nvim_tree", "plugins.configs.nvimtree"),
+      config = override_req("nvim_tree", "(plugins.configs.nvimtree).setup()"),
       setup = function()
          require("core.mappings").nvimtree()
       end,
@@ -217,7 +217,7 @@ return packer.startup(function()
       "nvim-telescope/telescope.nvim",
       module = "telescope",
       cmd = "Telescope",
-      config = override_req("telescope", "plugins.configs.telescope"),
+      config = override_req("telescope", "(plugins.configs.telescope).setup()"),
       setup = function()
          require("core.mappings").telescope()
       end,

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -32,21 +32,21 @@ return packer.startup(function()
    use {
       "kyazdani42/nvim-web-devicons",
       after = "nvim-base16.lua",
-      config = override_req("nvim_web_devicons", "(plugins.configs.icons).setup()"),
+      config = override_req("nvim_web_devicons", "plugins.configs.icons", "setup"),
    }
 
    use {
       "feline-nvim/feline.nvim",
       disable = not plugin_settings.status.feline,
       after = "nvim-web-devicons",
-      config = override_req("feline", "plugins.configs.statusline"),
+      config = override_req("feline", "plugins.configs.statusline", "setup"),
    }
 
    use {
       "akinsho/bufferline.nvim",
       disable = not plugin_settings.status.bufferline,
       after = "nvim-web-devicons",
-      config = override_req("bufferline", "(plugins.configs.bufferline).setup()"),
+      config = override_req("bufferline", "plugins.configs.bufferline", "setup"),
       setup = function()
          require("core.mappings").bufferline()
       end,
@@ -56,20 +56,20 @@ return packer.startup(function()
       "lukas-reineke/indent-blankline.nvim",
       disable = not plugin_settings.status.blankline,
       event = "BufRead",
-      config = override_req("indent_blankline", "(plugins.configs.others).blankline()"),
+      config = override_req("indent_blankline", "plugins.configs.others", "blankline"),
    }
 
    use {
       "norcalli/nvim-colorizer.lua",
       disable = not plugin_settings.status.colorizer,
       event = "BufRead",
-      config = override_req("nvim_colorizer", "(plugins.configs.others).colorizer()"),
+      config = override_req("nvim_colorizer", "plugins.configs.others", "colorizer"),
    }
 
    use {
       "nvim-treesitter/nvim-treesitter",
       event = "BufRead",
-      config = override_req("nvim_treesitter", "(plugins.configs.treesitter).setup()"),
+      config = override_req("nvim_treesitter", "plugins.configs.treesitter", "setup"),
    }
 
    -- git stuff
@@ -77,7 +77,7 @@ return packer.startup(function()
       "lewis6991/gitsigns.nvim",
       disable = not plugin_settings.status.gitsigns,
       opt = true,
-      config = override_req("gitsigns", "(plugins.configs.others).gitsigns()"),
+      config = override_req("gitsigns", "plugins.configs.others", "gitsigns"),
       setup = function()
          require("core.utils").packer_lazy_load "gitsigns.nvim"
       end,
@@ -102,7 +102,7 @@ return packer.startup(function()
       "ray-x/lsp_signature.nvim",
       disable = not plugin_settings.status.lspsignature,
       after = "nvim-lspconfig",
-      config = override_req("signature", "(plugins.configs.others).signature()"),
+      config = override_req("signature", "plugins.configs.others", "signature"),
    }
 
    use {
@@ -118,7 +118,7 @@ return packer.startup(function()
       "max397574/better-escape.nvim",
       disable = not plugin_settings.status.better_escape,
       event = "InsertEnter",
-      config = override_req("better_escape", "(plugins.configs.others).better_escape()"),
+      config = override_req("better_escape", "plugins.configs.others", "better_escape"),
    }
 
    -- load luasnips + cmp related in insert mode only
@@ -133,7 +133,7 @@ return packer.startup(function()
       "hrsh7th/nvim-cmp",
       disable = not plugin_settings.status.cmp,
       after = plugin_settings.options.cmp.lazy_load and "friendly-snippets",
-      config = override_req("nvim_cmp", "(plugins.configs.cmp).setup()"),
+      config = override_req("nvim_cmp", "plugins.configs.cmp", "setup"),
    }
 
    use {
@@ -141,7 +141,7 @@ return packer.startup(function()
       disable = not plugin_settings.status.cmp,
       wants = "friendly-snippets",
       after = plugin_settings.options.cmp.lazy_load and "nvim-cmp",
-      config = override_req("luasnip", "(plugins.configs.others).luasnip()"),
+      config = override_req("luasnip", "plugins.configs.others", "luasnip"),
    }
 
    use {
@@ -178,7 +178,7 @@ return packer.startup(function()
       "windwp/nvim-autopairs",
       disable = not plugin_settings.status.autopairs,
       after = plugin_settings.options.cmp.lazy_load and plugin_settings.options.autopairs.loadAfter,
-      config = override_req("nvim_autopairs", "(plugins.configs.others).autopairs()"),
+      config = override_req("nvim_autopairs", "plugins.configs.others", "autopairs"),
    }
 
    use {
@@ -194,7 +194,7 @@ return packer.startup(function()
       "numToStr/Comment.nvim",
       disable = not plugin_settings.status.comment,
       module = "Comment",
-      config = override_req("nvim_comment", "(plugins.configs.others).comment()"),
+      config = override_req("nvim_comment", "plugins.configs.others", "comment"),
       setup = function()
          require("core.mappings").comment()
       end,
@@ -207,7 +207,7 @@ return packer.startup(function()
       -- only set "after" if lazy load is disabled and vice versa for "cmd"
       after = not plugin_settings.options.nvimtree.lazy_load and "nvim-web-devicons",
       cmd = plugin_settings.options.nvimtree.lazy_load and { "NvimTreeToggle", "NvimTreeFocus" },
-      config = override_req("nvim_tree", "(plugins.configs.nvimtree).setup()"),
+      config = override_req("nvim_tree", "plugins.configs.nvimtree", "setup"),
       setup = function()
          require("core.mappings").nvimtree()
       end,
@@ -217,7 +217,7 @@ return packer.startup(function()
       "nvim-telescope/telescope.nvim",
       module = "telescope",
       cmd = "Telescope",
-      config = override_req("telescope", "(plugins.configs.telescope).setup()"),
+      config = override_req("telescope", "plugins.configs.telescope", "setup"),
       setup = function()
          require("core.mappings").telescope()
       end,


### PR DESCRIPTION
# Implements support for #620: Add/Remove/Overwrite individual keys in the NvChad Plugins Setup tables

### The following plugins (with their corresponding chadrc override key in parenthesis  for convenience) support table overrides:

- bufferline.nvim (bufferline)
- comment.nvim (nvim_comment)
- gitsigns (gitsigns)
- indent-blankline.nvim
- LuaSnip (luasnip)
- lsp_signature (signature)
- nvim-autopairs (nvim_autopairs)
- nvim-cmp (nvim_cmp)
- nvim-colorizer (nvim_colorizer)
- nvim-lspconfig (nvim_lspconfig)
- nvim-tree (nvim_tree)
- nvim-treesitter (nvim_treesitter)
- nvim-web-devicons (nvim_web_devicons)
- Telescope (telescope)

### The following plugins do not support table overrides but all defaults are configurable via chadrc's options section

- better-escape
- dashboard-nvim

### The following plugins do not make use of unified setup tables like the others, and thus do not support table overrides and require their own configuration files to change their behavior:

-  lspconfig
-  lsp_handler

### Examples of usage for various plugins:
_**Note: See the nvim_cmp section of the below example for how to override lspkind_icons as part of cmp**_
```
default_plugin_config_replace = {
   telescope = { defaults = { prompt_prefix = " ?  "}},
   nvim_treesitter = { highlight = { enable = true}},
   nvim_autopairs = {},
   nvim_web_devicons = {
      override ={
         lua = {
            icon = "L",
            name = "lua",
         },
      }
   },
   gitsigns = {
      signs = {
         add = { hl = "DiffAdd", text = ">", numhl = "GitSignsAddNr" },
      }
   },
   nvim_colorizer = {  --foreground should be black instead of background: #000000
      user_default_options = {
           mode = "foreground"
      },
   },
   bufferline = { options= {buffer_close_icon = "+"}},

   signature="custom.plugins.overrides.cmp_configs.lspsignature_cmp",
   feline="custom.plugins.overrides.statusline_builder.builder",
   
   nvim_cmp = { --To override icons the rest of the format function must be copied here as well
      formatting = {
         format = function(entry, vim_item)
            local icons = require "plugins.configs.lspkind_icons"
            
            _**--The following line edits lspkind_icons and is not from the original config**_
            icons = vim.tbl_deep_extend("force", icons, { Text="[]", TypeParameter="[]", Unit="[]"})
            
            vim_item.kind = string.format("%s %s", icons[vim_item.kind], vim_item.kind)

            vim_item.menu = ({
               nvim_lsp = "[LSP]",
               nvim_lua = "[Lua]",
               buffer = "[BUF]",
            })[entry.source.name]

            return vim_item
         end,
      },
   }
},
```
### Implementation notes and reasonings

The changes to plugin configurations to return a table and then be called via setup() (or setup(true) if overridden) from init.lua rather than just requiring the module are necessary since any implementation which does not return a table (like the ones mentioned prior in #620) involve adding some level of runtime overhead even for those not taking advantage of the feature (which out of principle I would refuse to implement, as were such a change merged I would make a fork removing it). You can easily tell that the initial implementations had runtime implications as any change made in the way shown prior in #620 would take effect on restart, while adding a new configuration file requires packer to recompile to update. 

The implementation in this PR maintains runtime efficiency and consistency, as it is only on recompile that the new table based overrides are checked for. While some slight overhead  is inevitable for those who make use of the feature (in the order of one or two milliseconds for multiple overrides according to tests on my old laptop), anyone who does not do so will be entirely unaffected. Thus, the primary motivation for the changes was consistency with expected behavior, while a secondary effect was some slight optimizations. A happy side effect is that the config section of each plugin in init.lua actually became more standardized, as configs contained within others.lua were function calls, while ones in their own files simply required the files. Now, nearly everything is a function call.

As a side note for the maintainers, while I normally would have made this all one commit, it was not really possible to do so while maintaining clarity of exactly what was changed/added and why in the commit message as so many files in multiple locations had to be edited to add support. If necessary, I can turn this into one commit, but I think that for house-keeping's sake 3 are necessary.
