### PR TITLE
feat: Add config.plugins.status.snippets to enable/disable snippets

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -68,6 +68,7 @@ M.plugins = {
       lspsignature = true, -- lsp enhancements
       vim_matchup = true, -- improved matchit
       cmp = true,
+      snippets = true,
       nvimtree = true,
       autopairs = true,
    },

--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -4,10 +4,12 @@ if not present then
    return
 end
 
+local snippets_status = require("core.utils").load_config().plugins.status.snippets
+
 vim.opt.completeopt = "menuone,noselect"
 
 local default = {
-   snippet = {
+   snippet = snippets_status and {
       expand = function(args)
          require("luasnip").lsp_expand(args.body)
       end,
@@ -40,7 +42,7 @@ local default = {
       ["<Tab>"] = function(fallback)
          if cmp.visible() then
             cmp.select_next_item()
-         elseif require("luasnip").expand_or_jumpable() then
+         elseif snippents_status and require("luasnip").expand_or_jumpable() then
             vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-expand-or-jump", true, true, true), "")
          else
             fallback()
@@ -49,7 +51,7 @@ local default = {
       ["<S-Tab>"] = function(fallback)
          if cmp.visible() then
             cmp.select_prev_item()
-         elseif require("luasnip").jumpable(-1) then
+         elseif snippets_status and require("luasnip").jumpable(-1) then
             vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-jump-prev", true, true, true), "")
          else
             fallback()

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -128,19 +128,20 @@ return packer.startup(function()
       "rafamadriz/friendly-snippets",
       module = 'cmp_nvim_lsp',
       disable = not plugin_settings.status.cmp,
+      disable = not (plugin_settings.status.cmp and plugin_settings.status.snippets),
       event = "InsertEnter",
    }
 
    use {
       "hrsh7th/nvim-cmp",
       disable = not plugin_settings.status.cmp,
-      after ="friendly-snippets",
+      after = plugin_settings.status.snippets and "friendly-snippets",
       config = override_req("nvim_cmp", "plugins.configs.cmp", "setup"),
    }
 
    use {
       "L3MON4D3/LuaSnip",
-      disable = not plugin_settings.status.cmp,
+      disable = not (plugin_settings.status.cmp and plugin_settings.status.snippets),
       wants = "friendly-snippets",
       after =  "nvim-cmp",
       config = override_req("luasnip", "plugins.configs.others", "luasnip"),
@@ -148,14 +149,14 @@ return packer.startup(function()
 
    use {
       "saadparwaiz1/cmp_luasnip",
-      disable = not plugin_settings.status.cmp,
+      disable = not (plugin_settings.status.cmp and plugin_settings.status.snippets),
       after = plugin_settings.options.cmp.lazy_load and "LuaSnip",
    }
 
    use {
       "hrsh7th/cmp-nvim-lua",
       disable = not plugin_settings.status.cmp,
-      after = "cmp_luasnip",
+      after = (plugin_settings.status.snippets and "cmp_luasnip") or "nvim-cmp",
    }
 
    use {

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -131,10 +131,13 @@ return packer.startup(function()
       disable = not (plugin_settings.status.cmp and plugin_settings.status.snippets),
       event = "InsertEnter",
    }
-
+   
+  -- cmp by default loads after friendly snippets 
+  -- if snippets are disabled -> cmp loads on insertEnter!
    use {
       "hrsh7th/nvim-cmp",
       disable = not plugin_settings.status.cmp,
+      event = plugin_settings.status.snippets and 'InsertEnter',
       after = plugin_settings.status.snippets and "friendly-snippets",
       config = override_req("nvim_cmp", "plugins.configs.cmp", "setup"),
    }


### PR DESCRIPTION
I thought many users dont use snippets, so they would like to disable it.

This option remove snippets plugins from order of lazy loading and remove it use from cmp mapping