### PR TITLE
improve startup time with shada load deferral

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -3,6 +3,13 @@ local g = vim.g
 
 local options = require("core.utils").load_config().options
 
+--Defer loading shada until after startup
+vim.opt.shadafile = "NONE"
+vim.defer_fn(function()
+   vim.opt.shadafile = vim.fn.expand("$HOME") .. "/.local/share/nvim/shada/main.shada"
+   vim.cmd[[ rsh ]]
+end, 0)
+
 opt.title = true
 opt.clipboard = options.clipboard
 opt.cmdheight = options.cmdheight


### PR DESCRIPTION
This just sets shada to none so it isn't read during startup, and then sets it to the normal location and reads it after startup. For some users the difference may be negligible, but many plugins will write to shada and over time command history etc fills up and this can save a lot of time.

Once, before discovering this, I saw shada took like 15ms to load and I checked it, and it had over 13k lines.... I had to just delete the file to restore startup times, this should avoid situations like that.

Even having cleaned it pretty recently, this change saves me around 3-4ms for each startup.