### PR TITLE
Added some additional chadrc.lua configuration for beginners

### DIFF
--- a/examples/chadrc.lua
+++ b/examples/chadrc.lua
@@ -1,5 +1,14 @@
 -- This is an example chadrc file , its supposed to be placed in /lua/custom/
 
+-- Will fix Error detected while processing VimEnter Autocommands for "*":
+-- Feline needs 'termguicolors' to be enabled to work properly
+vim.o.termguicolors = true
+
+-- Displays line numbers
+vim.o.number = true                                                                                 
+
+-- Makes line numbers relative to cursor position
+vim.o.relativenumber = true
 local M = {}
 
 -- make sure you maintain the structure of `core/default_config.lua` here,


### PR DESCRIPTION
Features Added:
Added a few configuration files to help vim/neovim and lua beginners (like me) get started much faster.

- On first install of NvChad, I had the error
`Error detected while processing VimEnter Autocommands for "*": `
`Feline needs 'termguicolors' to be enabled to work properly `

Fixed issue by setting termguicolors to true, which took me a while as a beginner.

- Added line numbers as well as relative line numbers


Reasoning:
- As a beginner trying to learn neovim/lua, these things took me a while to figure out. It might help other beginners.
- Ease of use for beginners; less time spent trying to look how to implement these features

