### PR TITLE
fix acid blue cursor

### DIFF
--- a/lua/colors/highlights.lua
+++ b/lua/colors/highlights.lua
@@ -91,6 +91,7 @@ fg_bg("DiffDelete", red, "NONE")
 
 -- Indent blankline plugin
 fg("IndentBlanklineChar", line)
+fg("IndentBlanklineSpaceChar", line)
 
 -- Lsp diagnostics
 


### PR DESCRIPTION
This fixes the acid blue cursor when using alacritty. Fixes #200 