### PR TITLE
improve method of adding and removing plugins

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -280,23 +280,35 @@ M.tbl_override_req = function(name, default_table)
    return vim.tbl_deep_extend("force", default_table, override)
 end
 
-M.remove_default_plugins = function(plugin_table)
-   local removals = require("core.utils").load_config().plugins.default_plugin_remove or {}
-   local result = {}
-
-   if vim.tbl_isempty(removals) then
-      return plugin_table
+--provide labels to plugins instead of integers
+M.label_plugins = function(plugins)
+   plugins_labeled = {}
+   for _, plugin in ipairs(plugins) do
+      plugins_labeled[plugin[1]] = plugin
    end
+   return plugins_labeled
+end
 
-   for _, value in pairs(plugin_table) do
-      for _, plugin in ipairs(removals) do
-         if value[1] ~= plugin then
-            table.insert(result, value)
-         end
+-- remove plugins specified by user from the plugins table
+M.remove_default_plugins = function(plugins)
+   local removals = require("core.utils").load_config().plugins.default_plugin_remove or {}
+   if not vim.tbl_isempty(removals) then
+      for _, plugin in pairs(removals) do
+         plugins[plugin] = nil
       end
    end
+   return plugins
+end
 
-   return result
+-- append user plugins to default plugins
+M.add_user_plugins = function(plugins)
+   local user_Plugins = require("core.utils").load_config().plugins.install or {}
+   if not vim.tbl_isempty(user_Plugins) then
+      for _, v in pairs(user_Plugins) do
+         plugins[v[1]] = v
+      end
+   end
+   return plugins
 end
 
 return M

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -224,18 +224,16 @@ local plugins = {
       end,
    },
 }
+
+--label plugins for operational assistance
+plugins = require("core.utils").label_plugins(plugins)
 --remove plugins specified in chadrc
 plugins = require("core.utils").remove_default_plugins(plugins)
+--add plugins specified in chadrc
+plugins = require("core.utils").add_user_plugins(plugins)
 
--- append user plugins to default plugins
-local user_Plugins = plugin_settings.install
-
-if type(user_Plugins) == "table" then
-   if table.maxn(user_Plugins) == 1 then
-      plugins[#plugins + 1] = user_Plugins[1]
-   else
-      plugins[#plugins + 1] = user_Plugins
+return packer.startup(function(use)
+   for _, v in pairs(plugins_labeled) do
+      use(v)
    end
-end
-
-return packer.startup { plugins }
+end)


### PR DESCRIPTION
@siduck @Akianonymus  This is a solution which I should have thought of ages ago during the dispute around having a labeled plugin table or not. This PR leaves the current table unchanged and therefore "pretty" as it is, but the functions for merging changes from chadrc are vastly simplified.

I've been having issues with an error message about using the same plugins multiple times on vanilla NvChad with just a basic chadrc, and the current logic for adding and removing plugins, while improved since the first iteration, remains somewhat difficult to debug and therefore is not ideal. These changes fix all that.

Notable improvements include:
1. If the user has a plugin in their custom plugin table which is already in the default table, their plugin will automatically take the place of the default one without error.
2. There are never any errors or edge cases.
3. The user can have a labeled or unlabeled plugin table and it will accept either.
4. By extension of 3, it's not a breaking change
5. The code for adding and removing plugins is much, much cleaner
6. The code for adding and removing plugins is much, much more efficient
7. I don't have to maintain a fork anymore lmao