### PR TITLE
fix global variable causing issues

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -282,7 +282,7 @@ end
 
 --provide labels to plugins instead of integers
 M.label_plugins = function(plugins)
-   plugins_labeled = {}
+   local plugins_labeled = {}
    for _, plugin in ipairs(plugins) do
       plugins_labeled[plugin[1]] = plugin
    end

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -233,7 +233,7 @@ plugins = require("core.utils").remove_default_plugins(plugins)
 plugins = require("core.utils").add_user_plugins(plugins)
 
 return packer.startup(function(use)
-   for _, v in pairs(plugins_labeled) do
+   for _, v in pairs(plugins) do
       use(v)
    end
 end)


### PR DESCRIPTION
In the last PR , while moving code from init.lua to utils I forgot to declare a var as a local and left the wrong one was referenced in init.lua without throwing an error because of it, which may have been causing some issues. This fixes it.

Also see #824 for an unrelated, but probably larger, issue that I discovered while debugging this one.