### PR TITLE
fix autocmd breaking term plugins

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -1,3 +1,4 @@
+local settings=require("core.utils").load_config().options.nvChad
 -- uncomment this if you want to open nvim with a dir
 -- vim.cmd [[ autocmd BufEnter * if &buftype != "terminal" | lcd %:p:h | endif ]]
 
@@ -6,7 +7,9 @@
 -- vim.cmd[[ au InsertLeave * set relativenumber ]]
 
 -- Don't show any numbers inside terminals
-vim.cmd [[ au TermOpen term://* setlocal nonumber norelativenumber | setfiletype terminal ]]
+if not settings.terminal_numbers then
+   vim.cmd [[ au TermOpen term://* setlocal nonumber norelativenumber | setfiletype terminal ]]
+end
 
 -- Don't show status line on certain windows
 vim.cmd [[ autocmd BufEnter,BufRead,BufWinEnter,FileType,WinEnter * lua require("core.utils").hide_statusline() ]]

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -7,7 +7,7 @@ local settings=require("core.utils").load_config().options.nvChad
 -- vim.cmd[[ au InsertLeave * set relativenumber ]]
 
 -- Don't show any numbers inside terminals
-if not settings.terminal_numbers then
+if not settings.terminal_linenr then
    vim.cmd [[ au TermOpen term://* setlocal nonumber norelativenumber | setfiletype terminal ]]
 end
 

--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -34,6 +34,7 @@ M.options = {
       copy_del = true, -- copy deleted text ( dd key ), visual and normal mode
       insert_nav = true, -- navigation in insertmode
       window_nav = true,
+      terminal_numbers = false,
 
       -- updater
       update_url = "https://github.com/NvChad/NvChad",

--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -34,7 +34,7 @@ M.options = {
       copy_del = true, -- copy deleted text ( dd key ), visual and normal mode
       insert_nav = true, -- navigation in insertmode
       window_nav = true,
-      terminal_numbers = false,
+      terminal_linenr = true,
 
       -- updater
       update_url = "https://github.com/NvChad/NvChad",


### PR DESCRIPTION
While taking a look at #829 and #824 I realized my local fix for toggleterm would show up as a change and it was kinda annoying. This is a quick fix allowing the user to disable the autocmd which makes nvchad not place nice with term plugins.

Really only temporarily needed until I have time to fully implement #811 