### PR TITLE
fix for getting config settings from plugin table

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -303,6 +303,9 @@ end
 -- append user plugins to default plugins
 M.add_user_plugins = function(plugins)
    local user_Plugins = require("core.utils").load_config().plugins.install or {}
+   if type(user_Plugins) == "string"
+      then user_Plugins=require(user_Plugins)
+   end
    if not vim.tbl_isempty(user_Plugins) then
       for _, v in pairs(user_Plugins) do
          plugins[v[1]] = v


### PR DESCRIPTION
Fixes https://github.com/NvChad/NvChad/issues/824

This allows 'install' in chadrc to be a string, meaning that the plugin table won't be loaded every time the config is. This should give a light performance boost as well as fixing the breakage caused by requiring the config from the plugin table.

To prevent this from being a breaking change, table values and require("some.user.table") are still accepted. Users who wish to reference plugins.status from their config table, or boost their config's efficiency should use install = "some.user.table" instead though.