### PR TITLE
feat: Run `:TSUpdate` on TS Install / Update

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -67,6 +67,7 @@ local plugins = {
       "nvim-treesitter/nvim-treesitter",
       event = "BufRead",
       config = override_req("nvim_treesitter", "plugins.configs.treesitter", "setup"),
+      run = ":TSUpdate",
    },
 
    -- git stuff


### PR DESCRIPTION
TreeSitter recommends running `:TSUpdate` after update with TS or on (re-)installation of Treesitter. Reference example recommended by TS: https://github.com/nvim-treesitter/nvim-treesitter/wiki/Installation