### PR TITLE
Make lsp keybindings take effect

### DIFF
--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -1,4 +1,5 @@
 require("plugins.configs.others").lsp_handlers()
+require("core.mappings").lspconfig()
 
 local function on_attach(_, bufnr)
    local function buf_set_option(...)
@@ -7,8 +8,6 @@ local function on_attach(_, bufnr)
 
    -- Enable completion triggered by <c-x><c-o>
    buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
-
-   require("core.mappings").lspconfig()
 end
 
 local capabilities = vim.lsp.protocol.make_client_capabilities()


### PR DESCRIPTION
With the current config, the keybinding defined in `core/mapping` for lspconfig does not take effect. I don't see the clear benefit of defining these keybindings with the `on_attach` function. Thus, I propose to move it out to the same level as `lsp_handlers`.