### PR TITLE
fix for (#844) Replace-paste at end of line incorrect

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -26,7 +26,7 @@ local M = {}
 M.misc = function()
    local function non_config_mappings()
       -- Don't copy the replaced text after pasting in visual mode
-      map_wrapper("v", "p", '"_dP')
+      map_wrapper("v", "p", 'p:let @+=@0<CR>')
 
       -- Allow moving the cursor through wrapped lines with j, k, <Up> and <Down>
       -- http://www.reddit.com/r/vim/comments/2k4cbr/problem_with_gj_and_gk/


### PR DESCRIPTION
When trying to replace-paste text at the end of a line results in the letter before the to be replaced text to be moved at the end of line after the replacement text. See, #844 for more details.

This is a known issue with the used mapping for paste on visual select, see https://vim.fandom.com/wiki/Replace_a_word_with_yanked_text#Mapping_for_paste . That same page also offers an alternative mapping which solves this issue. 

The mapping was tested using five different use cases, see https://github.com/NvChad/NvChad/issues/844#issuecomment-1053533198 for additional information on this test.