### PR TITLE
fix for treesitter not loading on creating new file

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -65,7 +65,7 @@ local plugins = {
 
    {
       "nvim-treesitter/nvim-treesitter",
-      event = "BufRead",
+      event = {"BufRead", "BufNewFile"},
       config = override_req("nvim_treesitter", "plugins.configs.treesitter", "setup"),
       run = ":TSUpdate",
    },


### PR DESCRIPTION
Currently if you open neovim on a file that doesn't yet exist or have any content (for example: nvim newfile.lua') treesitter will not load until you quit and reopen the file. This makes it so that it will still load on the file if the extension matches an install parser, no write and restart needed.