### PR TITLE
Luasnip support <Tab> jump between snippets in visual mode

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -37,7 +37,7 @@ local default = {
          behavior = cmp.ConfirmBehavior.Replace,
          select = true,
       },
-      ["<Tab>"] = function(fallback)
+      ["<Tab>"] = cmp.mapping(function(fallback)
          if cmp.visible() then
             cmp.select_next_item()
          elseif require("luasnip").expand_or_jumpable() then
@@ -45,8 +45,8 @@ local default = {
          else
             fallback()
          end
-      end,
-      ["<S-Tab>"] = function(fallback)
+      end, { "i", "s" }),
+      ["<S-Tab>"] = cmp.mapping(function(fallback)
          if cmp.visible() then
             cmp.select_prev_item()
          elseif require("luasnip").jumpable(-1) then
@@ -54,7 +54,7 @@ local default = {
          else
             fallback()
          end
-      end,
+      end, { "i", "s" }),
    },
    sources = {
       { name = "nvim_lsp" },


### PR DESCRIPTION
Some snippets support set a default value for the snippet body. This support use <Tab> to jump to the next part without changing the default values.