### PR TITLE
More intuitive method for setting Neovim/Vim options. Less work for the user and developer.

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -4,29 +4,34 @@
 local M = {}
 
 M.options = {
-   -- custom = {}
-   -- general nvim/vim options , check :h optionname to know more about an option
-
-   clipboard = "unnamedplus",
-   cmdheight = 1,
-   ruler = false,
-   hidden = true,
-   ignorecase = true,
-   smartcase = true,
-   mapleader = " ",
-   mouse = "a",
-   number = true,
-   numberwidth = 2,
-   relativenumber = false,
-   expandtab = true,
-   shiftwidth = 2,
-   smartindent = true,
-   tabstop = 8,
-   timeoutlen = 400,
-   updatetime = 250,
-   undofile = true,
-   fillchars = { eob = " " },
-   shadafile = vim.opt.shadafile,
+   -- general nvim/vim options, check :h optionname to know more about an option
+   nvim = {
+      clipboard = "unnamedplus",
+      cmdheight = 1,
+      cursorline = true, -- recommended to not change
+      expandtab = true,
+      fillchars = { eob = " " },
+      hidden = true,
+      ignorecase = true,
+      mouse = "a",
+      number = true,
+      numberwidth = 2,
+      relativenumber = false,
+      ruler = false,
+      shadafile = "NONE",
+      shiftwidth = 2,
+      signcolumn = "yes", -- recommended to not change
+      smartcase = true,
+      smartindent = true,
+      splitbelow = true, -- recommended to not change
+      splitright = true, -- recommended to not change
+      tabstop = 8, -- recommended to not change
+      termguicolors = true, -- recommended to not change
+      timeoutlen = 400,
+      title = true, -- recommended to not change
+      undofile = true,
+      updatetime = 250,
+   },
 
    -- NvChad options
    nvChad = {
@@ -119,6 +124,8 @@ M.plugins = {
 -- non plugin
 M.mappings = {
    -- custom = {}, -- custom user mappings
+
+   mapleader = " ", -- sets the leader key for mappings - <leader>
 
    misc = {
       cheatsheet = "<leader>ch",

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -9,6 +9,8 @@ local nvChad_options = config.options.nvChad
 
 local cmd = vim.cmd
 
+vim.g.mapleader = maps.mapleader
+
 -- This is a wrapper function made to disable a plugin mapping from chadrc
 -- If keys are nil, false or empty string, then the mapping will be not applied
 -- Useful when one wants to use that keymap for any other purpose

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -1,51 +1,30 @@
-local opt = vim.opt
-local g = vim.g
+local opt, g = vim.opt, vim.g
+local opts = require("core.utils").load_config().options
 
-local options = require("core.utils").load_config().options
+local function load_nvim_opts(nvim_opts)
+   for nvim_opt, set in pairs(nvim_opts) do
+      opt[nvim_opt] = set
+   end
+end
 
-opt.title = true
-opt.clipboard = options.clipboard
-opt.cmdheight = options.cmdheight
-opt.cul = true -- cursor line
-
--- Indentline
-opt.expandtab = options.expandtab
-opt.shiftwidth = options.shiftwidth
-opt.smartindent = options.smartindent
-
--- disable tilde on end of buffer: https://github.com/neovim/neovim/pull/8546#issuecomment-643643758
-opt.fillchars = options.fillchars
-
-opt.hidden = options.hidden
-opt.ignorecase = options.ignorecase
-opt.smartcase = options.smartcase
-opt.mouse = options.mouse
-
--- Numbers
-opt.number = options.number
-opt.numberwidth = options.numberwidth
-opt.relativenumber = options.relativenumber
-opt.ruler = options.ruler
-
--- disable nvim intro
+-- options that cannot be set by the user
 opt.shortmess:append "sI"
-
-opt.signcolumn = "yes"
-opt.splitbelow = true
-opt.splitright = true
-opt.tabstop = options.tabstop
-opt.termguicolors = true
-opt.timeoutlen = options.timeoutlen
-opt.undofile = options.undofile
-
--- interval for writing swap file to disk, also used by gitsigns
-opt.updatetime = options.updatetime
-
--- go to previous/next line with h,l,left arrow and right arrow
--- when cursor reaches end/beginning of line
 opt.whichwrap:append "<>[]hl"
+opt.shadafile = "NONE"
 
-g.mapleader = options.mapleader
+-- if there is an error with the user config, fallback onto the default config
+-- and print an error message
+local nvim_opts_status, _ = pcall(load_nvim_opts, opts.nvim)
+if not nvim_opts_status then
+   opts = require("core.default_config").options
+   load_nvim_opts(opts.nvim)
+   print "Error: user config - `options` - `nvim`"
+end
+
+vim.schedule(function()
+   opt.shadafile = require("core.utils").load_config().options.nvim.shadafile
+   vim.cmd [[ silent! rsh ]]
+end)
 
 -- disable some builtin vim plugins
 local disabled_built_ins = {
@@ -72,10 +51,3 @@ local disabled_built_ins = {
 for _, plugin in pairs(disabled_built_ins) do
    g["loaded_" .. plugin] = 1
 end
-
---Defer loading shada until after startup_
-vim.opt.shadafile = "NONE"
-vim.schedule(function()
-   vim.opt.shadafile = require("core.utils").load_config().options.shadafile
-   vim.cmd [[ silent! rsh ]]
-end)


### PR DESCRIPTION
**The Following Is Simply An Advertisement For A Trash Product**

Do you want less work for your developers and users?
Well, switch to `for` loops now which are much more intuitive and requires much less work. Now your users no longer need to go through the hassle of making their own damn `lua` file just to load some options. And you no longer have to type out the damn option every single time yourself.

**Disclaimer**

Your customers will be angry at you because this breaks their config and they may need to rework a few things. For example, take 2 seconds to copy and paste their previous options into `M.options.nvim` in the `chadrc.lua` file.

As far as I can see, I have not noticed a startuptime difference (`nvim --startuptime random_file_i_forgot_about`).

By the way, this solves nothing at all!

**Another Disclaimer**

The mapleader option can now be found in `M.mappings.mapleader` in the `chadrc.lua` file for the user and `default_config.lua` file for the developers looking for it.

***Please don't ban me for opening an absolutely useless pull request. I swear I can contribute more than 2 lines of code.***