### PR TITLE
fix(null-ls): stop null-ls prompt for multiple formaters

### DIFF
--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -1,10 +1,12 @@
 require("plugins.configs.others").lsp_handlers()
 
-local function on_attach(_, bufnr)
+local function on_attach(client, bufnr)
    local function buf_set_option(...)
       vim.api.nvim_buf_set_option(bufnr, ...)
    end
 
+   client.resolved_capabilities.document_formatting = false
+   client.resolved_capabilities.document_range_formatting = false
    -- Enable completion triggered by <c-x><c-o>
    buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
 


### PR DESCRIPTION
Features Added:
- No prompt for null-ls required (2 formaters)

Reasoning:
Every time I execute `<leader>fm` it prompt asking which of the, in my case, 2 formatters I'd like to use. In most if not all case it's the previously configured through null-ls formatter.

Other:
message @ 4e68ee06
```
add `client.resolved_capabilities.{document_formatting,document_range_formatting}` to on\_attach of lspconfig in order to eliminate null-ls prompt for 2 formaters. Not tested with more formatters like in python, I'd say that then it'll prompt still.

Signed-off-by: Daniel Boll <danielboll.academico@gmail.com>
```

I don't know if this should be considered going to the upstream repo as null-ls isn't officially supported within NvChad, although suggested.

Best Regards,
Daniel Boll. :flower_playing_cards: 
