### PR TITLE
fix nvimtree vim globals not having any effect

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -1,9 +1,4 @@
-local present, nvimtree = pcall(require, "nvim-tree")
-
-if not present then
-   return
-end
-
+-- globals must be set prior to requiring nvim-tree to function
 local g = vim.g
 
 g.nvim_tree_add_trailing = 0 -- append a trailing slash to folder names
@@ -39,6 +34,12 @@ g.nvim_tree_icons = {
       symlink_open = "",
    },
 }
+
+local present, nvimtree = pcall(require, "nvim-tree")
+
+if not present then
+   return
+end
 
 local default = {
    filters = {


### PR DESCRIPTION
Currently, changing any of the options stored in vim globals has no effect. This can be easily reproduced by attempting to disable folder icons by changing the code in the default file like so:
```
g.nvim_tree_show_icons = {
   folders = 1,
   files = 1,
   git = 1,
}
```
to 
```
g.nvim_tree_show_icons = {
   folders = 0,
   files = 0,
   git = 1,
}
```
The icons will still be there on restart. With the change to move the setting globals above the require statement in this patch, the above code functions properly.
