### PR TITLE
feat: support themes other than defaults

### DIFF
--- a/lua/colors/init.lua
+++ b/lua/colors/init.lua
@@ -13,22 +13,34 @@ M.init = function(theme)
 
    if present then
       -- first load the base16 theme
-      base16(base16.themes(theme), true)
+      local ok, array = pcall(base16.themes, theme)
 
-      -- unload to force reload
-      package.loaded["colors.highlights" or false] = nil
-      -- then load the highlights
-      require "colors.highlights"
+      if ok then
+         base16(array, true)
+         -- unload to force reload
+         package.loaded["colors.highlights" or false] = nil
+         -- then load the highlights
+         require "colors.highlights"
+      else
+         pcall(vim.cmd, "colo " .. theme)
+      end
+   else
+      pcall(vim.cmd, "colo " .. theme)
    end
 end
 
 -- returns a table of colors for given or current theme
 M.get = function(theme)
-   if not theme then
-      theme = vim.g.nvchad_theme
-   end
+   local colors = require("core.utils").load_config().ui.colors
 
-   return require("hl_themes." .. theme)
+   if #colors ~= 0 then
+      return require(colors)
+   else
+      if not theme then
+         theme = vim.g.nvchad_theme
+      end
+      return require("hl_themes." .. theme)
+   end
 end
 
 return M

--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -46,6 +46,7 @@ M.options = {
 
 M.ui = {
    hl_override = "", -- path of your file that contains highlights
+   colors = "", -- path of your file that contains colors
    italic_comments = false,
    theme = "onedark", -- default theme
 


### PR DESCRIPTION
With this pr, users could use any themes they want. Specifically, 
1.  add themes to `userPlugins`
```lua
--  custom/plugins/inited.lua
...
{ "local/path/to/mytheme" }, -- local
{ "Iron-E/nvim-highlite" }, -- remote
...
```
2.  add colors file (i.e. `custom/colors.lua`) in format of [this](https://github.com/NvChad/nvim-base16.lua/blob/master/lua/hl_themes/aquarium.lua)
3.  set colors and theme in `chadrc.lua`
```lua
-- custom/chadrc.lua
...
M.ui = {
  theme = "mytheme",
  -- theme = "highlite",
  colors = "custom.colors",
}
...
```

Related to #631.