### PR TITLE
add new location option for chadterm to default config

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -48,6 +48,10 @@ M.options = {
          vsplit_ratio = 0.5,
          split_ratio = 0.4,
       },
+      location = {
+         horizontal = "rightbelow",
+         vertical = "rightbelow",
+      },
    },
 }
 


### PR DESCRIPTION
Chadterm will no longer overlap with nvimtree by default, but people who want to use the old splitting method or others can do so by setting the horizontal and vertical fields in options.terminal.location from chadrc.

NvChad/extensions#11 has been PR'd and fixes the issues with bufferline and nvimtree mentioned in #925 