### PR TITLE
refactor: bad module name for `friendly-snippets`

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -19,9 +19,9 @@ local plugins = {
 
    {
       "NvChad/extensions",
-      config = function ()
+      config = function()
          vim.schedule_wrap(require("nvchad.terminal").init())
-      end
+      end,
    },
 
    {
@@ -130,7 +130,6 @@ local plugins = {
 
    {
       "rafamadriz/friendly-snippets",
-      module = "cmp_nvim_lsp",
       disable = not plugin_settings.status.cmp,
       event = "InsertEnter",
    },


### PR DESCRIPTION
I don't know the reason behind that naming but It's a bad name. I think "friendly-snippets" is good enough.