### PR TITLE
feat: make `friendly-snippets` optional

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -109,6 +109,7 @@ M.plugins = {
       cmp = true,
       nvimtree = true,
       autopairs = true,
+      friendly_snippets = true, -- set of preconfigured snippets for different languages
    },
    options = {
       packer = {

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -19,9 +19,9 @@ local plugins = {
 
    {
       "NvChad/extensions",
-      config = function ()
+      config = function()
          vim.schedule_wrap(require("nvchad.terminal").init())
-      end
+      end,
    },
 
    {
@@ -131,14 +131,14 @@ local plugins = {
    {
       "rafamadriz/friendly-snippets",
       module = "cmp_nvim_lsp",
-      disable = not plugin_settings.status.cmp,
+      disable = not (plugin_settings.status.cmp and plugin_settings.status.friendly_snippets),
       event = "InsertEnter",
    },
 
    {
       "hrsh7th/nvim-cmp",
       disable = not plugin_settings.status.cmp,
-      after = "friendly-snippets",
+      after = plugin_settings.status.friendly_snippets and "friendly-snippets",
       config = override_req("nvim_cmp", "plugins.configs.cmp", "setup"),
    },
 


### PR DESCRIPTION
Not everyone wants this particular snippet library and not everyone even needs a snippet library. In the current setup, it's impossible to remove this plugin because `nvim-cmp` depends on it, so made it optional :)

related: https://github.com/NvChad/NvChad/discussions/893#discussion-3954190