### PR TITLE
chore: migrate to neovim v0.7

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -1,20 +1,51 @@
-local settings=require("core.utils").load_config().options.nvChad
--- uncomment this if you want to open nvim with a dir
--- vim.cmd [[ autocmd BufEnter * if &buftype != "terminal" | lcd %:p:h | endif ]]
+local settings = require("core.utils").load_config().options.nvChad
+
+-- Uncomment this if you want to open nvim with a dir
+-- vim.api.nvim_create_autocmd("BufEnter", { command = [[if &buftype != "terminal" | lcd %:p:h | endif]] })
 
 -- Use relative & absolute line numbers in 'n' & 'i' modes respectively
--- vim.cmd[[ au InsertEnter * set norelativenumber ]]
--- vim.cmd[[ au InsertLeave * set relativenumber ]]
+-- vim.api.nvim_create_autocmd("InsertEnter", {
+--    callback = function()
+--       vim.opt.relativenumber = false
+--    end,
+-- })
+-- vim.api.nvim_create_autocmd("InsertLeave", {
+--    callback = function()
+--       vim.opt.relativenumber = true
+--    end,
+-- })
 
 -- Don't show any numbers inside terminals
 if not settings.terminal_numbers then
-   vim.cmd [[ au TermOpen term://* setlocal nonumber norelativenumber | setfiletype terminal ]]
+   vim.api.nvim_create_autocmd("TermOpen", {
+      pattern = "term://*",
+      callback = function()
+         vim.opt_local.number = false
+         vim.opt_local.relativenumber = false
+         vim.cmd [[ setfiletype terminal ]]
+      end,
+   })
 end
 
 -- Don't show status line on certain windows
-vim.cmd [[ autocmd BufEnter,BufRead,BufWinEnter,FileType,WinEnter * lua require("core.utils").hide_statusline() ]]
+vim.api.nvim_create_autocmd({ "BufEnter", "BufRead", "BufWinEnter", "FileType", "WinEnter" }, {
+   callback = function()
+      require("core.utils").hide_statusline()
+   end,
+})
 
 -- Open a file from its last left off position
--- vim.cmd [[ au BufReadPost * if expand('%:p') !~# '\m/\.git/' && line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g'\"" | endif ]]
+-- vim.api.nvim_create_autocmd("BufReadPost", {
+--    command = [[ if expand('%:p') !~# '\m/\.git/' && line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g'\"" | endif ]],
+-- })
+
 -- File extension specific tabbing
--- vim.cmd [[ autocmd Filetype python setlocal expandtab tabstop=4 shiftwidth=4 softtabstop=4 ]]
+-- vim.api.nvim_create_autocmd("Filetype", {
+--    pattern = "python",
+--    callback = function()
+--       vim.opt_local.expandtab = true
+--       vim.opt_local.tabstop = 4
+--       vim.opt_local.shiftwidth = 4
+--       vim.opt_local.softtabstop = 4
+--    end,
+-- })

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -158,22 +158,6 @@ M.map = function(mode, keys, command, opt)
       options = vim.tbl_extend("force", options, opt)
    end
 
-   -- all valid modes allowed for mappings
-   -- :h map-modes
-   local valid_modes = {
-      [""] = true,
-      ["n"] = true,
-      ["v"] = true,
-      ["s"] = true,
-      ["x"] = true,
-      ["o"] = true,
-      ["!"] = true,
-      ["i"] = true,
-      ["l"] = true,
-      ["c"] = true,
-      ["t"] = true,
-   }
-
    -- helper function for M.map
    -- can gives multiple modes and keys
    local function map_wrapper(sub_mode, lhs, rhs, sub_options)
@@ -182,20 +166,7 @@ M.map = function(mode, keys, command, opt)
             map_wrapper(sub_mode, key, rhs, sub_options)
          end
       else
-         if type(sub_mode) == "table" then
-            for _, m in ipairs(sub_mode) do
-               map_wrapper(m, lhs, rhs, sub_options)
-            end
-         else
-            if valid_modes[sub_mode] and lhs and rhs then
-               vim.api.nvim_set_keymap(sub_mode, lhs, rhs, sub_options)
-            else
-               sub_mode, lhs, rhs = sub_mode or "", lhs or "", rhs or ""
-               print(
-                  "Cannot set mapping [ mode = '" .. sub_mode .. "' | key = '" .. lhs .. "' | cmd = '" .. rhs .. "' ]"
-               )
-            end
-         end
+         vim.keymap.set(sub_mode, lhs, rhs, sub_options)
       end
    end
 
@@ -303,8 +274,8 @@ end
 -- append user plugins to default plugins
 M.add_user_plugins = function(plugins)
    local user_Plugins = require("core.utils").load_config().plugins.install or {}
-   if type(user_Plugins) == "string"
-      then user_Plugins=require(user_Plugins)
+   if type(user_Plugins) == "string" then
+      user_Plugins = require(user_Plugins)
    end
    if not vim.tbl_isempty(user_Plugins) then
       for _, v in pairs(user_Plugins) do

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -10,7 +10,6 @@ local override_req = require("core.utils").override_req
 local plugins = {
    { "nvim-lua/plenary.nvim" },
    { "lewis6991/impatient.nvim" },
-   { "nathom/filetype.nvim" },
 
    {
       "wbthomason/packer.nvim",
@@ -19,9 +18,9 @@ local plugins = {
 
    {
       "NvChad/extensions",
-      config = function ()
+      config = function()
          vim.schedule_wrap(require("nvchad.terminal").init())
-      end
+      end,
    },
 
    {


### PR DESCRIPTION
- the `filetype.nvim` plugin is removed since `filetype.lua` is build into neovim v0.7
- autocommands are written with Lua
- `utils.map` is rewritten to use `vim.keymap` instead of `nvim_set_keymap`

TODO:
- [ ] rewrite highlight utils with `nvim_set_hl`