### PR TITLE
add disable option for statusline hide autocmd

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -12,7 +12,9 @@ if not settings.terminal_numbers then
 end
 
 -- Don't show status line on certain windows
-vim.cmd [[ autocmd BufEnter,BufRead,BufWinEnter,FileType,WinEnter * lua require("core.utils").hide_statusline() ]]
+if not require("core.utils").load_config().plugins.options.statusline.hide_disable then
+   vim.cmd [[ autocmd BufEnter,BufRead,BufWinEnter,FileType,WinEnter * lua require("core.utils").hide_statusline() ]]
+end
 
 -- Open a file from its last left off position
 -- vim.cmd [[ au BufReadPost * if expand('%:p') !~# '\m/\.git/' && line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g'\"" | endif ]]

--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -129,6 +129,7 @@ M.plugins = {
          snippet_path = {},
       },
       statusline = {
+         hide_disable = false,
          -- hide, show on specific filetypes
          hidden = {
             "help",


### PR DESCRIPTION
Description in title. Discovered when trying to test out global statusline that statusline_hide() always sets laststatus regardless of user options, making global statusline impossible to enable. 

I I thought about adding a specific global option, but that's up to you @siduck, since I know you are trying to keep down bloat. Regardless, there should never be a case where we have an autocmd set an option and not have an option to disable it. 