### PR TITLE
override default branch for bufferline

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -47,6 +47,7 @@ local plugins = {
 
    {
       "akinsho/bufferline.nvim",
+      branch = "main",
       disable = not plugin_settings.status.bufferline,
       after = "nvim-web-devicons",
       config = override_req("bufferline", "plugins.configs.bufferline", "setup"),


### PR DESCRIPTION
By default packer tries to use "master" for the branch of any plugin that doesn't have a branch explicitly defined. However, the bufferline authors recently renamed their default branch from "master" to main. Thus, packer will work fine with bufferline for any new clones, but it will fail to update for anyone who had the old branch name "master" set.

See also: https://github.com/wbthomason/packer.nvim/issues/86