### PR TITLE
Typecheck return value of chadrc; propagate errors

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -141,12 +141,16 @@ end
 M.load_config = function()
    local conf = require "core.default_config"
 
-   local chadrcExists, change = pcall(require, "custom.chadrc")
-
-   -- if chadrc exists , then merge its table into the default config's
-
-   if chadrcExists then
-      conf = vim.tbl_deep_extend("force", conf, change)
+   -- attempt to load and merge a user config
+   local chadrc_exists = vim.fn.filereadable(vim.fn.stdpath "config" .. "/lua/custom/chadrc.lua") == 1
+   if chadrc_exists then
+      -- merge user config if it exists and is a table; otherwise display an error
+      local user_config = require "custom.chadrc"
+      if type(user_config) == 'table' then
+         conf = vim.tbl_deep_extend("force", conf, user_config)
+      else
+         error("User config (chadrc.lua) *must* return a table!")
+      end
    end
 
    return conf


### PR DESCRIPTION
Currently NvChad silently fails when some newbie screws up their `custom/chadrc.lua`, and because they're a newbie they either uninstall NvChad, revert to the base config, or stay up all night debugging in a language they don't understand (yet)  😅 

* Explicitly check if chadrc.lua exists and is readable (same as is done for `custom/init.vim`
* Don't assume the only way `require "custom/chadrc.lua"` can fail is that the file doesn't exist (as was implied by var names/lack of alternative error handling)
* Provide user with a more useful message when return type is wrong
* `thisIsntJava` and everything else is using `snake_case`, so `chadrcExists` -> `chadrc_exists`

The previous behavior suppresses valuable error information and simple syntax error into a multi-hour debug-athon Related (last paragraph): https://github.com/NvChad/NvChad/issues/922#issuecomment-1094174054