### PR TITLE
fix: move option "nvim_tree_indent_markers" to setup

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -4,7 +4,6 @@ local g = vim.g
 g.nvim_tree_add_trailing = 0 -- append a trailing slash to folder names
 g.nvim_tree_git_hl = 0
 g.nvim_tree_highlight_opened_files = 0
-g.nvim_tree_indent_markers = 1
 g.nvim_tree_root_folder_modifier = table.concat { ":t:gs?$?/..", string.rep(" ", 1000), "?:gs?^??" }
 
 g.nvim_tree_show_icons = {
@@ -72,6 +71,11 @@ local default = {
          resize_window = true,
       },
    },
+   renderer = {
+      indent_markers = {
+         enable = true,
+      }
+   }
 }
 
 local M = {}


### PR DESCRIPTION
The NvimTree has moved the option "nvim_tree_indent_markers" to setup in their latest version.

kyazdani42/nvim-tree.lua#1134

