### PR TITLE
feat(statusline): add laststatus option

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -147,6 +147,8 @@ M.plugins = {
          },
          shown = {},
 
+         -- global statusline (if set to 3)
+         laststatus = 2,
          -- truncate statusline on small screens
          shortline = true,
          style = "default", -- default, round , slant , block , arrow

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -121,12 +121,13 @@ end
 M.hide_statusline = function()
    local hidden = require("core.utils").load_config().plugins.options.statusline.hidden
    local shown = require("core.utils").load_config().plugins.options.statusline.shown
+   local last = require("core.utils").load_config().plugins.options.statusline.laststatus
    local api = vim.api
    local buftype = api.nvim_buf_get_option(0, "ft")
 
    -- shown table from config has the highest priority
    if vim.tbl_contains(shown, buftype) then
-      api.nvim_set_option("laststatus", 2)
+      api.nvim_set_option("laststatus", last)
       return
    end
 
@@ -135,7 +136,7 @@ M.hide_statusline = function()
       return
    end
 
-   api.nvim_set_option("laststatus", 2)
+   api.nvim_set_option("laststatus", last)
 end
 
 M.load_config = function()


### PR DESCRIPTION
## Is this a breaking change (Yes/No):
No

## Is this commit require Neovim-v0.7+ (Yes/No):
No

## Behavior
**`laststatus = 3` only support on Neovim-v0.7+ .** 

### **Run for more info:**
- `:help statusline`
- `:help laststatus`

Refs: https://github.com/neovim/neovim/issues/9342 & https://github.com/neovim/neovim/commit/be15ac06badbea6b11390ad7d9c2ddd4aea73480
