### PR TITLE
chore: add `FixCursorHold` plugin

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -11,6 +11,7 @@ local plugins = {
    { "nvim-lua/plenary.nvim" },
    { "lewis6991/impatient.nvim" },
    { "nathom/filetype.nvim" },
+   { "antoinemadec/FixCursorHold.nvim" },
 
    {
       "wbthomason/packer.nvim",
@@ -19,9 +20,9 @@ local plugins = {
 
    {
       "NvChad/extensions",
-      config = function ()
+      config = function()
          vim.schedule_wrap(require("nvchad.terminal").init())
-      end
+      end,
    },
 
    {


### PR DESCRIPTION
`CursorHold` and `CursorHoldI` events have a bug that is not resolved yet(https://github.com/neovim/neovim/issues/12587). I think it's a performance issue. The core team suggests not using it but one of our default plugins relies on it: ([ray-x/lsp_signature.nvim](https://github.com/ray-x/lsp_signature.nvim/blob/a351509512687293fd659ba4ee7e34412c3a8f70/lua/lsp_signature/init.lua#L647)). Another famous plugin that relies on `CursorHold` is [nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring).

The `FixCursorHold` plugin somehow fixes this bug and I think it's good to have this plugin by default. Even LunarVim uses it.