### PR TITLE
added gc and gb as keys to trigger lazy load on comment plugin

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -192,7 +192,7 @@ local plugins = {
       "numToStr/Comment.nvim",
       disable = not plugin_settings.status.comment,
       module = "Comment",
-      keys = { "gcc" },
+      keys = { "gc", "gb" },
       config = override_req("nvim_comment", "plugins.configs.others", "comment"),
       setup = function()
          require("core.mappings").comment()


### PR DESCRIPTION
The `Comment.nvim` plugin now correctly lazy loads. :)
Before it did not lazy load for things like `gcaw`, `gbaw` in normal mode or `gc` in visual mode.