### PR TITLE
chore: disable omnifunc

### DIFF
--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -9,8 +9,6 @@ function M.on_attach(client, bufnr)
 
    client.resolved_capabilities.document_formatting = false
    client.resolved_capabilities.document_range_formatting = false
-   -- Enable completion triggered by <c-x><c-o>
-   buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
 
    require("core.mappings").lspconfig()
 end


### PR DESCRIPTION
The [lspconfig documents](https://github.com/neovim/nvim-lspconfig/wiki/Autocompletion#nvim-cmp) don't suggest using `omnifunc` when using `nvim-cmp`:
> If you are using nvim-cmp do not use neovim's built-in omnifunc as it cannot support the additional completion items returned from servers due to the capabilities enabled by nvim-cmp.