### PR TITLE
refactor: remove `noremap` from `utils.map`

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -41,7 +41,7 @@ M.load_config = function()
 end
 
 M.map = function(mode, keys, command, opt)
-   local options = { noremap = true, silent = true }
+   local options = { silent = true }
 
    if opt then
       options = vim.tbl_extend("force", options, opt)


### PR DESCRIPTION
`vim.keymap.set` mappings are not recursive by default (remap = false). actually `vim.keymap.set` ignores `noremap` and overrides its value based on the value of `remap` which is false by default (as stated [here](https://neovim.discourse.group/t/which-one-has-more-precedence-noremap-or-remap/2526/2))