### PR TITLE
feat: add more autocommands

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -41,3 +41,18 @@ local autocmd = vim.api.nvim_create_autocmd
 --       vim.opt_local.softtabstop = 4
 --    end,
 -- })
+
+-- Highlight yanked text
+-- autocmd("TextYankPost", {
+--    callback = function()
+--       vim.highlight.on_yank { higroup = "Visual", timeout = 200 }
+--    end,
+-- })
+
+-- Enable spellchecking in markdown, text and gitcommit files
+-- autocmd("FileType", {
+--    pattern = { "gitcommit", "markdown", "text" },
+--    callback = function()
+--       vim.opt_local.spell = true
+--    end,
+-- })


### PR DESCRIPTION
The first one highlights the yanked text for 200 ms so we can we what is yanked.
The second one enables built-in spellchecking in text, markdown, and gitcommit files.