### PR TITLE
clearer display of open folders in nvimtree

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -34,7 +34,7 @@ g.nvim_tree_icons = {
       default = "",
       empty = "",
       empty_open = "",
-      open = " ",
+      open = "",
       symlink = "",
       symlink_open = "",
    },


### PR DESCRIPTION
Open folders are confusing since they indent to a level which visually indicates they are a subfolder of the folder above them in the tree.

For comparison, before this change:
![before](https://user-images.githubusercontent.com/695089/166678108-fe16000e-72c1-450b-8d25-da13e22375f7.png)

After this change:
![after](https://user-images.githubusercontent.com/695089/166678145-c5f0f52e-0a2b-4ae7-8193-704174c2f526.png)

