### PR TITLE
Update cmp.lua, fixes tab autocomplete not working after calling Telescope

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -69,7 +69,6 @@ local options = {
       end, {
          "i",
          "s",
-         "c",
       }),
       ["<S-Tab>"] = cmp.mapping(function(fallback)
          if cmp.visible() then
@@ -82,7 +81,6 @@ local options = {
       end, {
          "i",
          "s",
-         "c",
       }),
    },
    sources = {


### PR DESCRIPTION
This PR fixes issue #1031 that arose from commit 08e9ab363e3486034db0de4a42992c86bfedfb2c, causing tab autocomplete to not work after calling Telescope.