### PR TITLE
Fix deprecated client_capabilities usage

### DIFF
--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -9,8 +9,8 @@ local M = {}
 require("plugins.configs.others").lsp_handlers()
 
 function M.on_attach(client, _)
-   client.resolved_capabilities.document_formatting = false
-   client.resolved_capabilities.document_range_formatting = false
+   client.server_capabilities.document_formatting = false
+   client.server_capabilities.document_range_formatting = false
 
    require("core.mappings").lspconfig()
 end


### PR DESCRIPTION
`client_capabilities` is now deprecated, `server_capabilities` does the same thing.