### PR TITLE
BREAKING CHANGE: Rewrote lsp server configuration & made it modular

### DIFF
--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -1,19 +1,11 @@
-local present, lspconfig = pcall(require, "lspconfig")
+local lsp_config_present, lspconfig = pcall(require, "lspconfig")
+local lsp_installer_present, lsp_installer = pcall(require, "nvim-lsp-installer")
 
-if not present then
-   return
+if not lsp_config_present or not lsp_installer_present then
+  return
 end
-
-local M = {}
 
 require("plugins.configs.others").lsp_handlers()
-
-function M.on_attach(client, _)
-   client.resolved_capabilities.document_formatting = false
-   client.resolved_capabilities.document_range_formatting = false
-
-   require("core.mappings").lspconfig()
-end
 
 local capabilities = vim.lsp.protocol.make_client_capabilities()
 capabilities.textDocument.completion.completionItem.documentationFormat = { "markdown", "plaintext" }
@@ -25,39 +17,73 @@ capabilities.textDocument.completion.completionItem.deprecatedSupport = true
 capabilities.textDocument.completion.completionItem.commitCharactersSupport = true
 capabilities.textDocument.completion.completionItem.tagSupport = { valueSet = { 1 } }
 capabilities.textDocument.completion.completionItem.resolveSupport = {
-   properties = {
-      "documentation",
-      "detail",
-      "additionalTextEdits",
-   },
+  properties = {
+    "documentation",
+    "detail",
+    "additionalTextEdits",
+  },
 }
 
-lspconfig.sumneko_lua.setup {
-   on_attach = M.on_attach,
-   capabilities = capabilities,
+local M = {}
 
-   settings = {
-      Lua = {
-         diagnostics = {
-            globals = { "vim" },
-         },
-         workspace = {
-            library = {
-               [vim.fn.expand "$VIMRUNTIME/lua"] = true,
-               [vim.fn.expand "$VIMRUNTIME/lua/vim/lsp"] = true,
-            },
-            maxPreload = 100000,
-            preloadFileSize = 10000,
-         },
+M.default_config = {
+  on_attach = function(client, _)
+    client.resolved_capabilities.document_formatting = false
+    client.resolved_capabilities.document_range_formatting = false
+
+    require("core.mappings").lspconfig()
+  end,
+  capabilities = capabilities,
+}
+
+M.sumneko_lua = {
+  on_attach = function(client, _)
+    M.default_config.on_attach(client, _)
+  end,
+  settings = {
+    Lua = {
+      diagnostics = {
+        globals = { "vim" },
       },
-   },
+      workspace = {
+        library = {
+          [vim.fn.expand "$VIMRUNTIME/lua"] = true,
+          [vim.fn.expand "$VIMRUNTIME/lua/vim/lsp"] = true,
+        },
+        maxPreload = 100000,
+        preloadFileSize = 10000,
+      },
+    },
+  },
 }
 
--- requires a file containing user's lspconfigs
+-- requires the file path field containing the user's lspconfig
 local addlsp_confs = require("core.utils").load_config().plugins.options.lspconfig.setup_lspconf
+local custom_lspconfig = nil
+local custom_servers = {}
 
+-- list of default servers to install
+local servers = { "sumneko_lua" }
+
+-- check if a custom lspconfig path is set and require it as well as the new configs
 if #addlsp_confs ~= 0 then
-   require(addlsp_confs).setup_lsp(M.on_attach, capabilities)
+  custom_lspconfig = require(addlsp_confs)
+  M = vim.tbl_deep_extend("force", M, custom_lspconfig.setup_lsp(M))
+  custom_servers = custom_lspconfig.servers or {}
+end
+
+-- gets a list of all installed lsp servers
+local installed_servers = vim.tbl_map(function(v) return v.name end,
+  lsp_installer.get_installed_servers())
+
+-- merge default, custom, and installed servers
+servers = vim.tbl_extend("force", servers, custom_servers, installed_servers)
+
+-- run the custom setup configurations if defined or the default one for each server
+for _, server in ipairs(servers) do
+  local lsp = M[server]
+  if not lsp then lsp = M.default_config end
+  lspconfig[server].setup(lsp)
 end
 
 return M


### PR DESCRIPTION
This is a breaking change but it is necessary to enable users to configure their LSPs in a modular way and it also makes the configuration part a lot easier. LSP servers that are installed using `LspInstall` or `LspInstallInfo` will now also be loaded with the default configuration even if they are not listed in the lspconfig's `M.servers` field. @siduck try it out and let me know what you think of this.

This is my current lspconfig.lua which stands as an example for how you would configure your LSPs.

```lua
-- $HOME/.config/nvim/lua/custom/plugins/lspconfig.lua

-- Here you can define your own setup parameters for each LSP as well as override the default configs

local LSP = {}

LSP.default_config = {
  on_attach = function(client, bufnr)
    -- enable document formatting
    client.server_capabilities.document_formatting = true
    client.server_capabilities.document_range_formatting = true

    -- if document formatting is enabled, set a keybinding to format the file or a selection
    if client.server_capabilities.document_formatting then
      vim.api.nvim_buf_set_keymap(bufnr, "n", "<space>fm", "<cmd>lua vim.lsp.buf.formatting()<CR>", {})
      vim.api.nvim_buf_set_keymap(bufnr, "v", "<space>fM", "<cmd>lua vim.lsp.buf.range_formatting()<CR>", {})

      -- format the file on save
      vim.cmd "autocmd BufWritePre <buffer> lua vim.lsp.buf.formatting_sync()"
    end

    -- print if the language server supports formatting
    print("LSP formatting enabled:", client.server_capabilities.document_formatting)

    -- require the default keybindings
    require("core.mappings").lspconfig()
  end,
}

-- This is only supposed to be an example on how to create a custom LSP configuration.
-- LSP.sumneko_lua = {
--   on_attach = function(client, _)
--     -- Put your code in here
--     LSP.default_config.on_attach(client, _)
--   end,
-- }

local M = {}

M.setup_lsp = function(lsp)
  -- here you can return the configurations for your LSP servers. The returned table will be
  -- deep-merged with the default one, which means that you can also override only parts of
  -- the default config (e.g. see above, LSP.sumneko_lua only changes the on_attach callback).
  -- IMPORTANT: if you would like to retain the default capabilities for a new custom server setup,
  -- you need to set the capabilities field.

  -- set the default capabilities to all custom LSP configs
  for k, _ in pairs(LSP) do
    LSP[k].capabilities = lsp.default_config.capabilities
  end

  return LSP
end

-- The list of LSP servers you would like to install and use by default.
-- Servers that are installed through :LspInstall will be automatically added to this list
-- automatically.
M.servers = {
  "jdtls",
  "pylsp",
  "clangd",
  "cssls",
  "html",
  "jsonls",
  "texlab",
  "sumneko_lua",
  "tsserver"
}

return M
```