### PR TITLE
feat: add protected require

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,7 @@ local core_modules = {
 }
 
 for _, module in ipairs(core_modules) do
-   local ok, err = pcall(require, module)
+   local ok, err = nvchad.prequire(module)
    if not ok then
       error("Error loading " .. module .. "\n\n" .. err)
    end
@@ -21,7 +21,7 @@ end
 -- check if custom init.lua file exists
 if vim.fn.filereadable(vim.fn.stdpath "config" .. "/lua/custom/init.lua") == 1 then
    -- try to call custom init, if not successful, show error
-   local ok, err = pcall(require, "custom")
+   local ok, err = nvchad.prequire "custom"
 
    if not ok then
       vim.notify("Error loading custom/init.lua\n\n" .. err)

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -86,7 +86,7 @@ nvchad.plugin_list = function(default_plugins)
    local ok
 
    if type(user_plugins) == "string" then
-      ok, user_plugins = pcall(require, user_plugins)
+      ok, user_plugins = nvchad.prequire(user_plugins)
       if ok and not type(user_plugins) == "table" then
          user_plugins = {}
       end
@@ -114,4 +114,12 @@ nvchad.load_override = function(default_table, plugin_name)
       default_table = default_table
    end
    return default_table
+end
+
+nvchad.prequire = function(module)
+   local ok, res = pcall(require, module)
+   if not ok then
+      return nil, res
+   end
+   return res
 end

--- a/lua/plugins/configs/alpha.lua
+++ b/lua/plugins/configs/alpha.lua
@@ -1,4 +1,4 @@
-local present, alpha = pcall(require, "alpha")
+local present, alpha = nvchad.prequire "alpha"
 
 if not present then
    return

--- a/lua/plugins/configs/bufferline.lua
+++ b/lua/plugins/configs/bufferline.lua
@@ -1,4 +1,4 @@
-local present, bufferline = pcall(require, "bufferline")
+local present, bufferline = nvchad.prequire "bufferline"
 
 if not present then
    return

--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -1,4 +1,4 @@
-local present, cmp = pcall(require, "cmp")
+local present, cmp = nvchad.prequire "cmp"
 
 if not present then
    return

--- a/lua/plugins/configs/icons.lua
+++ b/lua/plugins/configs/icons.lua
@@ -1,4 +1,4 @@
-local present, devicons = pcall(require, "nvim-web-devicons")
+local present, devicons = nvchad.prequire "nvim-web-devicons"
 
 if not present then
    return

--- a/lua/plugins/configs/lsp_installer.lua
+++ b/lua/plugins/configs/lsp_installer.lua
@@ -1,4 +1,4 @@
-local present, lsp_installer = pcall(require, "nvim-lsp-installer")
+local present, lsp_installer = nvchad.prequire "nvim-lsp-installer"
 
 if not present then
    return

--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -1,4 +1,4 @@
-local present, lspconfig = pcall(require, "lspconfig")
+local present, lspconfig = nvchad.prequire "lspconfig"
 
 if not present then
    return

--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -1,4 +1,4 @@
-local present, nvimtree = pcall(require, "nvim-tree")
+local present, nvimtree = nvchad.prequire "nvim-tree"
 
 if not present then
    return

--- a/lua/plugins/configs/nvterm.lua
+++ b/lua/plugins/configs/nvterm.lua
@@ -1,4 +1,4 @@
-local present, nvterm = pcall(require, "nvterm")
+local present, nvterm = nvchad.prequire "nvterm"
 
 if not present then
    return

--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 M.autopairs = function()
-   local present1, autopairs = pcall(require, "nvim-autopairs")
-   local present2, cmp = pcall(require, "cmp")
+   local present1, autopairs = nvchad.prequire "nvim-autopairs"
+   local present2, cmp = nvchad.prequire "cmp"
 
    if not present1 and present2 then
       return
@@ -19,7 +19,7 @@ M.autopairs = function()
 end
 
 M.better_escape = function()
-   local present, escape = pcall(require, "better_escape")
+   local present, escape = nvchad.prequire "better_escape"
 
    if not present then
       return
@@ -37,7 +37,7 @@ M.better_escape = function()
 end
 
 M.blankline = function()
-   local present, blankline = pcall(require, "indent_blankline")
+   local present, blankline = nvchad.prequire "indent_blankline"
 
    if not present then
       return
@@ -68,7 +68,7 @@ M.blankline = function()
 end
 
 M.colorizer = function()
-   local present, colorizer = pcall(require, "colorizer")
+   local present, colorizer = nvchad.prequire "colorizer"
 
    if not present then
       return
@@ -100,7 +100,7 @@ M.colorizer = function()
 end
 
 M.comment = function()
-   local present, nvim_comment = pcall(require, "Comment")
+   local present, nvim_comment = nvchad.prequire "Comment"
 
    if not present then
       return
@@ -110,7 +110,7 @@ M.comment = function()
 end
 
 M.luasnip = function()
-   local present, luasnip = pcall(require, "luasnip")
+   local present, luasnip = nvchad.prequire "luasnip"
 
    if not present then
       return
@@ -125,7 +125,7 @@ M.luasnip = function()
 end
 
 M.signature = function()
-   local present, lsp_signature = pcall(require, "lsp_signature")
+   local present, lsp_signature = nvchad.prequire "lsp_signature"
 
    if not present then
       return
@@ -194,7 +194,7 @@ M.lsp_handlers = function()
 end
 
 M.gitsigns = function()
-   local present, gitsigns = pcall(require, "gitsigns")
+   local present, gitsigns = nvchad.prequire "gitsigns"
 
    if not present then
       return

--- a/lua/plugins/configs/statusline.lua
+++ b/lua/plugins/configs/statusline.lua
@@ -1,4 +1,4 @@
-local present, feline = pcall(require, "feline")
+local present, feline = nvchad.prequire "feline"
 
 if not present then
    return

--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -1,4 +1,4 @@
-local present, telescope = pcall(require, "telescope")
+local present, telescope = nvchad.prequire "telescope"
 
 if not present then
    return

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -1,4 +1,4 @@
-local present, treesitter = pcall(require, "nvim-treesitter.configs")
+local present, treesitter = nvchad.prequire "nvim-treesitter.configs"
 
 if not present then
    return

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -1,5 +1,5 @@
 local plugin_settings = nvchad.load_config().plugins
-local present, packer = pcall(require, plugin_settings.options.packer.init_file)
+local present, packer = nvchad.prequire(plugin_settings.options.packer.init_file)
 
 if not present then
    return false

--- a/lua/plugins/packerInit.lua
+++ b/lua/plugins/packerInit.lua
@@ -18,7 +18,7 @@ if not present then
    }
 
    vim.cmd "packadd packer.nvim"
-   present, packer = pcall(require, "packer")
+   present, packer = nvchad.prequire "packer"
 
    if present then
       print "Packer cloned successfully."


### PR DESCRIPTION
It's a wrapper around `pcall(require, <module>)` that I stole from [NightVim](https://github.com/nyxkrage/NightVim/blob/dc526bc91d72bcbcf1e767b64461c899f32911ea/sysinit.lua#L72). It may look unnecessary here (which it is) but it makes it easier to do other stuff when importing a module, for example, showing an error if the module doesn't exist.
```lua
nvchad.prequire = function(module)
   local ok, res = pcall(require, module)
   if not ok then
      vim.notify("failed to load module" .. module, vim.log.levels.ERROR)
      -- you could also show some kinda hint to the newbie users, for example: 
      -- RUN :PackerSync
      return nil, res
   end
   return res
end
```
I didn't do that because I didn't want to break the current flow.		