### PR TITLE
feat: added which-key keymaps, fixed telescope keymap & custom "mode_opt" for keymaps

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -224,11 +224,11 @@ M.telescope = {
       -- find
       ["<leader>ff"] = { "<cmd> Telescope find_files <CR>", "  find files" },
       ["<leader>fa"] = { "<cmd> Telescope find_files follow=true no_ignore=true hidden=true <CR>", "  find all" },
-      ["<leader>fw"] = { "<cmd> Telescope live_grep <CR>", "  live grep" },
+      ["<leader>fw"] = { "<cmd> Telescope live_grep <CR>", "   live grep" },
       ["<leader>fb"] = { "<cmd> Telescope buffers <CR>", "  find buffers" },
       ["<leader>fh"] = { "<cmd> Telescope help_tags <CR>", "  help page" },
-      ["<leader>fo"] = { "<cmd> Telescope oldfiles <CR>", "  find oldfiles" },
-      ["<leader>tk"] = { "<cmd> Telescope keys <CR>", "   show keys" },
+      ["<leader>fo"] = { "<cmd> Telescope oldfiles <CR>", "   find oldfiles" },
+      ["<leader>tk"] = { "<cmd> Telescope keymaps <CR>", "   show keys" },
 
       -- git
       ["<leader>cm"] = { "<cmd> Telescope git_commits <CR>", "   git commits" },
@@ -283,6 +283,22 @@ M.nvterm = {
          "   new vertical term",
       },
    },
+}
+
+M.whichkey = {
+   n = {
+      ["<leader>wK"] = {
+         function()
+            vim.cmd("WhichKey")
+         end, "   which-key all keymaps",
+      },
+      ["<leader>wk"] = {
+         function()
+            local input = vim.fn.input("WhichKey: ")
+            vim.cmd("WhichKey " .. input)
+         end, "   which-key query lookup",
+      },
+   }
 }
 
 return M

--- a/lua/plugins/configs/whichkey.lua
+++ b/lua/plugins/configs/whichkey.lua
@@ -61,9 +61,10 @@ local mappings = nvchad.load_config().mappings
 
 -- register mappings
 for mode, opt in pairs(options.mode_opts) do
-   for key, _ in pairs(mappings) do
-      if mappings[key][mode] then
-         wk.register(mappings[key][mode], opt)
+   for _, value in pairs(mappings) do
+      if value[mode] then
+         local mode_opts = value["mode_opts"] and vim.tbl_deep_extend("force", opt, value["mode_opts"]) or opt
+         wk.register(value[mode], mode_opts)
       end
    end
 end


### PR DESCRIPTION
@siduck As the title suggests, I fixed some existing keymaps, added ones for which-key and added a feature where users can now set `mode_opts` per keymap. This is important for registering expressions or similar, however setting `mode_opts` is completely optional.

These are some of the `mode_opts` values that can be set:

```lua
-- IMPORTANT: `mode_opts` values will apply to all key mappings in `M.<YOUR_KEY_MAP_LIST>`

mode_opts =  {
  buffer = nil, -- Global mappings. Specify a buffer number for buffer local mappings
  silent = true, -- use `silent` when creating keymaps
  noremap = true, -- use `noremap` when creating keymaps
  nowait = false, -- use `nowait` when creating keymaps
  -- and more ...
}
```

Before it was not possible to add expressions or alter any other options on an extension basis. This can now be done like this

**NOTE**: `expr = true` will apply to all keymaps for `M.copilot`. If you only want some keymaps to have the specified `mode_opts` values, simply create another `M.<YOUR_KEY_MAP_LIST>` for the same extension (e.g. `M.copilot_2`):

```lua
-- Github Copilot Bindings
-----------------------------------------------------------
M.copilot = {
  mode_opts = { expr = true },
  i = {
    ["<C-H>"] = { 'copilot#Accept("<CR>")', "   copilot accept" },
  },
}
```