### PR TITLE
fix: remove disabled maps from which-key popup (again)

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -64,7 +64,7 @@ nvchad.remove_disabled_mappings = function(key_map)
       for k, v in pairs(key_map) do
          if v ~= nil and v ~= "" then clean_map[k] = v end
       end
-   else
+   elseif not key_map == nil and not key_map == "" then
       return key_map
    end
    return clean_map


### PR DESCRIPTION
@siduck This is just a small fix becuase disabled bindings showed up in which-key again. Also tested with fresh NvChad installation.