### PR TITLE
fix: which-key group names can now properly set with M.groups & refactoring

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -60,12 +60,13 @@ end
 -- remove disabled mappings from a given key map
 nvchad.remove_disabled_mappings = function(key_map)
    local clean_map = {}
+   if key_map == nil or key_map == "" then
+      return key_map
+   end
    if type(key_map) == "table" then
       for k, v in pairs(key_map) do
          if v ~= nil and v ~= "" then clean_map[k] = v end
       end
-   elseif not key_map == nil and not key_map == "" then
-      return key_map
    end
    return clean_map
 end
@@ -80,17 +81,14 @@ nvchad.prune_key_map = function(key_map, prune_map, ignore_modes)
    for ext, modes in pairs(key_map) do
       for mode, mappings in pairs(modes) do
          if not vim.tbl_contains(ignore_modes, mode) then
-            if prune_keys[mode] then
-               -- filter mappings table so that only keys that are not in user_mappings are left
-               local filtered_mappings = {}
-               for k, v in pairs(mappings) do
-                  if not vim.tbl_contains(prune_keys[mode], k) then
-                     filtered_mappings[k] = nvchad.remove_disabled_mappings(v)
-                  end
+            -- filter mappings table so that only keys that are not in user_mappings are left
+            for b, _ in pairs(mappings) do
+               if prune_keys[mode] and vim.tbl_contains(prune_keys[mode], b) then
+                  key_map[ext][mode][b] = nil
                end
-               key_map[ext][mode] = filtered_mappings
             end
          end
+         key_map[ext][mode] = nvchad.remove_disabled_mappings(mappings)
       end
    end
 

--- a/lua/plugins/configs/whichkey.lua
+++ b/lua/plugins/configs/whichkey.lua
@@ -58,16 +58,24 @@ local options = {
 require("plugins.configs.others").misc_mappings()
 
 local mappings = nvchad.load_config().mappings
+local mapping_groups = { groups = vim.deepcopy(mappings.groups) }
+mappings.disabled = nil
+mappings.groups = nil
 
 -- register mappings
-for mode, opt in pairs(options.mode_opts) do
-   for _, value in pairs(mappings) do
-      if value[mode] then
-         local mode_opts = value["mode_opts"] and vim.tbl_deep_extend("force", opt, value["mode_opts"]) or opt
-         wk.register(value[mode], mode_opts)
+local function register_mappings(maps, opts)
+   for mode, opt in pairs(opts.mode_opts) do
+      for _, value in pairs(maps) do
+         if value[mode] then
+            local mode_opts = value["mode_opts"] and vim.tbl_deep_extend("force", opt, value["mode_opts"]) or opt
+            wk.register(value[mode], mode_opts)
+         end
       end
    end
 end
+
+register_mappings(mappings, options)
+register_mappings(mapping_groups, options)
 
 options = nvchad.load_override(options, "folke/which-key.nvim")
 


### PR DESCRIPTION
@siduck Which-key group names can now be set properly using `M.groups` in custom mappings. Before, the group names would sometimes randomly not be set. I also refactored some minor things. This has been tested with a fresh NvChad install & which-key uninstalled + `nvchad.no_Which_key()`.

Before:

![Screenshot_20220516_144324](https://user-images.githubusercontent.com/55194243/168595078-030d9cdb-0119-4118-ac00-a1383f55520a.png)

After this PR:
![Screenshot_20220516_144115](https://user-images.githubusercontent.com/55194243/168594703-d87a8245-3b25-4103-98f0-4b6d2a3e66f1.png)
