### PR TITLE
fix(cmp): change the confirmation behaviour to `Insert`

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -55,7 +55,7 @@ local options = {
       ["<C-Space>"] = cmp.mapping.complete(),
       ["<C-e>"] = cmp.mapping.close(),
       ["<CR>"] = cmp.mapping.confirm {
-         behavior = cmp.ConfirmBehavior.Replace,
+         behavior = cmp.ConfirmBehavior.Insert,
          select = true,
       },
       ["<Tab>"] = cmp.mapping(function(fallback)


### PR DESCRIPTION
Am I the only one who thinks replacing the next word with the confirmed cmp suggestion is weird and annoying? Usually, we use cmp to "add" text not remove it.