### PR TITLE
fix: disable auto-pairing in javascript named imports

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -172,7 +172,7 @@ local plugins = {
 
    -- misc plugins
    ["windwp/nvim-autopairs"] = {
-      after = "nvim-cmp",
+      after = { "nvim-cmp", "nvim-treesitter" },
       config = function()
          require("plugins.configs.others").autopairs()
       end,


### PR DESCRIPTION
The problem is that when we use javascript named imports to import a function or method, `nvim-autopairs` adds a pair of parentheses after the function name which we never want. This PR disabled auto-pairing in javascript named imports. 

related: https://github.com/windwp/nvim-autopairs/issues/219