### PR TITLE
fix: update hide scrollbar logic to work with cmp

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -21,8 +21,11 @@ end
 
 local cmp_window = require "cmp.utils.window"
 
-function cmp_window:has_scrollbar()
-   return false
+cmp_window.info_ = cmp_window.info
+cmp_window.info = function(self)
+  local info = self:info_()
+  info.scrollable = false
+  return info
 end
 
 local options = {


### PR DESCRIPTION
Commit `fae808a2bca079ea9454f33cb1e2db81c59e102b` for the `nvim-cmp` plugin removed the `has_scrollbar` breaking how NvChad hides the scroll bar.  As a result, the scrollbar is visible when there are more menu items than the size of the window.

See the change [here](https://github.com/hrsh7th/nvim-cmp/commit/fae808a2bca079ea9454f33cb1e2db81c59e102b).

This proposed change wraps the call to `window:info` and sets the `info` table's `scrollable` property to `false` before returning the table to the caller.

This most likely went unnoticed because nothing calls `has_scrollbar`, so there was nothing to trigger an error.