### PR TITLE
fix: override options before register keys

### DIFF
--- a/lua/plugins/configs/whichkey.lua
+++ b/lua/plugins/configs/whichkey.lua
@@ -55,6 +55,8 @@ local options = {
    },
 }
 
+options = nvchad.load_override(options, "folke/which-key.nvim")
+
 local mappings = nvchad.load_config().mappings
 local mapping_groups = { groups = vim.deepcopy(mappings.groups) }
 
@@ -76,6 +78,5 @@ end
 register_mappings(mappings, options)
 register_mappings(mapping_groups, options)
 
-options = nvchad.load_override(options, "folke/which-key.nvim")
 
 wk.setup(options)


### PR DESCRIPTION
Hi, when I was creating my own configuration, I found this problem here.
According to `lua/plugins/configs/whichkey.lua`  we can override the config of the default `whichKey` plugin options.

```lua
M.plugins = {
   override = {
     ["folke/which-key.nvim"] = {
       mode_opts = {
        -- support add keymaps to visual block mode
         x = {
           mode = "x" 
         }
       }
     }
   }
}
```
Then in `custom.mappings` add the following section:

```lua
M.general = {
  x = {
      ["<A-h>"] = { "<cmd> lua print('just a example') <CR>", "example text" },
    }
}
```
This does not work, because the override happens only after calling `wk.register`:

https://github.com/NvChad/NvChad/blob/d264c3c8e11a1acde34f2f874f5bd353a8772d2f/lua/plugins/configs/whichkey.lua#L65-L79

So overriding the options won't change anything.  To fix this problem, we could just move the override call above the `register_mappings` function call. I've tested this change it in my own repo, it solves the problem.
