### PR TITLE
Load nvimtree with alpha so ignore_ft_on_setup actually works

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -186,6 +186,7 @@ local plugins = {
 
    -- file managing , picker etc
    ["kyazdani42/nvim-tree.lua"] = {
+      ft = 'alpha',
       cmd = { "NvimTreeToggle", "NvimTreeFocus" },
       config = function()
          require "plugins.configs.nvimtree"


### PR DESCRIPTION
Very hard to describe using words so here is a video

https://user-images.githubusercontent.com/56817415/169878130-9d3e5917-3a39-47fe-8760-d5a69cfa0ede.mp4

Minimal config used to reproduce the bug:
`/tmp/min.lua`
```lua
vim.cmd [[set runtimepath=$VIMRUNTIME]]
vim.cmd [[set packpath=/tmp/min/site]]
local package_root = "/tmp/min/site/pack"
local install_path = package_root .. "/packer/start/packer.nvim"
if vim.fn.isdirectory(install_path) == 0 then
	vim.fn.system { "git", "clone", "--depth=1", "https://github.com/wbthomason/packer.nvim", install_path }
end
require("packer").startup {
	{
		"wbthomason/packer.nvim",
		"kyazdani42/nvim-web-devicons",
		"akinsho/bufferline.nvim",
		"akinsho/toggleterm.nvim",
		"goolord/alpha-nvim"
	},
	config = {
		package_root = package_root,
		compile_path = install_path .. "/plugin/packer_compiled.lua",
		display = { non_interactive = true },
	},
}
require'packer'.use {
	'kyazdani42/nvim-tree.lua',
	-- ft = 'alpha',
	cmd = { "NvimTreeToggle", "NvimTreeFocus" },
	config = function() require'nvim-tree'.setup{} end
}
require("packer").sync()

vim.cmd [[autocmd User PackerComplete ++once echo "Ready!" | lua setup()]]
vim.opt.termguicolors = true
vim.opt.cursorline = true

_G.setup = function()
	require'alpha'.setup(require'alpha.themes.startify'.config)
	vim.cmd'Alpha'
	require'bufferline'.setup{ options = { offsets = { { filetype = "NvimTree", } }, } }
	require'toggleterm'.setup{}
	vim.keymap.set('n', '<C-n>', ':NvimTreeToggle<CR>')
end
```
