### PR TITLE
fix: moved lsp mappings to lspconfig to only be set on lsp attach

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -102,6 +102,8 @@ M.comment = {
 M.lspconfig = {
    -- See `<cmd> :help vim.lsp.*` for documentation on any of the below functions
 
+   ignore = { "/lua/plugins/configs/whichkey.lua" },
+
    n = {
       ["gD"] = {
          function()

--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -22,14 +22,64 @@ M.on_attach = function(client, bufnr)
    client.resolved_capabilities.document_formatting = false
    client.resolved_capabilities.document_range_formatting = false
 
-   local lsp_mappings = nvchad.load_config().mappings.lspconfig
-   local wk_exists, wk = pcall(require, "which-key")
+   local options = {
 
-   if wk_exists then
-      wk.register(lsp_mappings.n, { buffer = bufnr })
-   else
-      -- todo, make use of bufnr here
-      -- add no whichkey func logic here
+      -- NOTE : this mode_opts table isnt in the default whichkey config
+      --  Its added here so you could configure it in chadrc
+
+      mode_opts = {
+         n = {
+            mode = "n",
+         },
+
+         v = {
+            mode = "v",
+         },
+
+         i = {
+            mode = "i",
+         },
+
+         t = {
+            mode = "t",
+         },
+      },
+
+      icons = {
+         breadcrumb = "»", -- symbol used in the command line area that shows your active key combo
+         separator = "  ", -- symbol used between a key and it's label
+         group = "+", -- symbol prepended to a group
+      },
+
+      popup_mappings = {
+         scroll_down = "<c-d>", -- binding to scroll down inside the popup
+         scroll_up = "<c-u>", -- binding to scroll up inside the popup
+      },
+
+      window = {
+         border = "none", -- none/single/double/shadow
+      },
+
+      layout = {
+         spacing = 6, -- spacing between columns
+      },
+
+      hidden = { "<silent>", "<cmd>", "<Cmd>", "<CR>", "call", "lua", "^:", "^ " },
+
+      triggers_blacklist = {
+         -- list of mode / prefixes that should never be hooked by WhichKey
+         i = { "j", "k" },
+         v = { "j", "k" },
+      },
+   }
+
+   options = nvchad.load_override(options, "folke/which-key.nvim")
+
+   local lsp_mappings = { nvchad.load_config().mappings.lspconfig }
+   lsp_mappings[1]["mode_opts"] = { buffer = bufnr }
+
+   if not nvchad.whichKey_map(lsp_mappings, options) then
+      nvchad.no_WhichKey_table_map(lsp_mappings)
    end
 end
 

--- a/lua/plugins/configs/whichkey.lua
+++ b/lua/plugins/configs/whichkey.lua
@@ -63,21 +63,7 @@ local mapping_groups = { groups = vim.deepcopy(mappings.groups) }
 mappings.disabled = nil
 mappings.groups = nil
 
--- register mappings
-local function register_mappings(maps, opts)
-   for mode, opt in pairs(opts.mode_opts) do
-      for key, value in pairs(maps) do
-         if key ~= "lspconfig" then
-            if value[mode] then
-               local mode_opts = value["mode_opts"] and vim.tbl_deep_extend("force", opt, value["mode_opts"]) or opt
-               wk.register(value[mode], mode_opts)
-            end
-         end
-      end
-   end
-end
-
-register_mappings(mappings, options)
-register_mappings(mapping_groups, options)
+nvchad.whichKey_map(mappings, options)
+nvchad.whichKey_map(mapping_groups, options)
 
 wk.setup(options)


### PR DESCRIPTION
@siduck I moved the LSP mappings to `lspconfig.lua` and added some helper functions to ignore specific mappings, when the map function is called from a set of predefined file paths. This is done by listing them in the new `ignore` key in the plugin mappings that can hold a list of paths, which will cause those maps not to be applied when the map function is called from within those files. The nvim config location (i.e. `~/.config/nvim`) is the base path here, so all ignore entries can start from here (e.g. `/lua/plugins/configs/whichkey.lua` will cause the maps not to be set when the map function is called from within `whichkey.lua`). The issue we still have is that when registering the keys in `lspconfig.lua` we have to pass the options table, which I have (for now) simply copied from the which-key config into the `on_attach` function. It would however be better to get the table through a function call of some sort. I have tested the functionality using which-key but not without it, however my implementation should work (@siduck can you test it?). 