### PR TITLE
Use `server_capabilities` instead of `resolved_capabilities`

### DIFF
--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -19,8 +19,8 @@ win.default_opts = function(options)
 end
 
 function M.on_attach(client, _)
-   client.resolved_capabilities.document_formatting = false
-   client.resolved_capabilities.document_range_formatting = false
+   client.server_capabilities.document_formatting = false
+   client.server_capabilities.document_range_formatting = false
 end
 
 local capabilities = vim.lsp.protocol.make_client_capabilities()


### PR DESCRIPTION
`resolved_capabilities` is deprecated in nvim 0.8. All the field in `resolved_capabilities` should also be in `server_capabilities`.

See https://github.com/neovim/neovim/pull/17814