### PR TITLE
update depreciated functions

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -196,7 +196,7 @@ M.lspconfig = {
 
       ["<leader>fm"] = {
          function()
-            vim.lsp.buf.formatting()
+            vim.lsp.buf.format({async=true})
          end,
          "   lsp formatting",
       },

--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -20,8 +20,8 @@ win.default_opts = function(options)
 end
 
 M.on_attach = function(client, bufnr)
-   client.resolved_capabilities.document_formatting = false
-   client.resolved_capabilities.document_range_formatting = false
+   client.server_capabilities.document_formatting = false
+   client.server_capabilities.document_range_formatting = false
 
    local lsp_mappings = utils.load_config().mappings.lspconfig
    utils.load_mappings({ lsp_mappings }, { buffer = bufnr })


### PR DESCRIPTION
Neovim warns about `client.resolved_capabilities` and `vim.lsp.buf.formatting` being depreciated.

```
[LSP] Accessing client.resolved_capabilities is deprecated, update your plugins or configuration to access client.server_capabilities instead. 
The new key/value pairs in server_capabilities directly match those defined in the language server protocol
```

```
vim.lsp.buf.formatting is deprecated. Use vim.lsp.buf.format { async = true } instead
```