### PR TITLE
add option to override luasnip options

### DIFF
--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -123,11 +123,13 @@ M.luasnip = function()
       return
    end
 
-   luasnip.config.set_config {
+   local options = {
       history = true,
       updateevents = "TextChanged,TextChangedI",
    }
+   options = load_override(options, "L3MON4D3/LuaSnip")
 
+   luasnip.config.set_config(options)
    require("luasnip.loaders.from_vscode").lazy_load()
 end
 


### PR DESCRIPTION
For some reason, the `load_override` call for the luasnip setup was missing.