### PR TITLE
change proiority of completion list in nvim-cmp

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -87,8 +87,8 @@ local options = {
       }),
    },
    sources = {
-      { name = "nvim_lsp" },
       { name = "luasnip" },
+      { name = "nvim_lsp" },
       { name = "buffer" },
       { name = "nvim_lua" },
       { name = "path" },


### PR DESCRIPTION
Snippets suggestions comes more handy than language server suggestions in compeletion menu. so I filipped one line to give priority to luasnip. With this, snippets suggestions will apear first in completion menu.
I guess everyone would rather snippets first than lsp itself. 
BTW I didn't compare this with other editors, but I believe editors like vscode take advantage of this feature too.