### PR TITLE
Preventing comment on new line.

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -17,5 +17,11 @@ autocmd("BufUnload", {
    end,
 })
 
+-- Don't auto commenting new lines
+autocmd('BufEnter', {
+  pattern = '*',
+  command = 'set fo-=c fo-=r fo-=o'
+})
+
 -- load statusline
 vim.opt.statusline = "%!v:lua.require'ui.statusline'.run()"


### PR DESCRIPTION
Added an autocmd to prevent commenting on new lines.

```lua
-- Don't auto commenting new lines
autocmd('BufEnter', {
  pattern = '*',
  command = 'set fo-=c fo-=r fo-=o'
})
```