### PR TITLE
Adding configuration for file_info path statusline

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -35,6 +35,7 @@ M.plugins = {
       },
       statusline = {
          separator_style = "default", -- default/round/block
+         file_info_style = "default", -- default/full_path
          config = "%!v:lua.require'ui.statusline'.run()",
       },
    },

--- a/lua/ui/statusline.lua
+++ b/lua/ui/statusline.lua
@@ -22,6 +22,20 @@ local sep_style = {
    },
 }
 
+local file_info_styles = {
+  default = function()
+    return fn.fnamemodify(fn.expand "%:t", ":r")
+  end,
+
+  full_path = function ()
+    return fn.expand "%"
+  end
+}
+
+local user_file_info_style = require("core.utils").load_config().plugins.options.statusline.file_info_style
+local file_info_style = file_info_styles[user_file_info_style]
+
+
 local user_sep_style = require("core.utils").load_config().plugins.options.statusline.separator_style
 local sep_l = sep_style[user_sep_style]["left"]
 local sep_r = sep_style[user_sep_style]["right"]
@@ -62,7 +76,7 @@ end
 
 M.fileInfo = function()
    local icon = ""
-   local filename = fn.fnamemodify(fn.expand "%:t", ":r")
+   local filename = file_info_style()
    local extension = fn.expand "%:e"
 
    if filename == "" then


### PR DESCRIPTION
I was facing an annoying issue lately where I was editing a lot of files with the same name.
I updated my configuration to have the opportunity to define a full path instead of just a file name.

Here's what I did, I'm open to any suggestion to improve that kind of configuration.
I didn't want to go to a fully customizable statusline because the PR would have been much longer, and I only had an issue with FileInfo, but feel free to suggest changes for future usages.
 
Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>