### PR TITLE
fetch correct lsp name in status bar while existing multi actived lsp clients

### DIFF
--- a/lua/ui/statusline.lua
+++ b/lua/ui/statusline.lua
@@ -150,8 +150,15 @@ M.LSP_Diagnostics = function()
 end
 
 M.LSP_status = function()
-   local lsp_attached = next(vim.lsp.buf_get_clients()) ~= nil
-   local content = lsp_attached and "   LSP ~ " .. vim.lsp.get_active_clients()[1].name .. " " or false
+   local clients = vim.lsp.get_active_clients()
+   local name = false
+   for _, client in ipairs(clients) do
+     if client.attached_buffers[vim.api.nvim_get_current_buf()] then
+       name = client.name
+       break
+     end
+   end
+   local content = name and "   LSP ~ " .. name .. " " or false
    return content and ("%#St_LspStatus#" .. content) or ""
 end
 


### PR DESCRIPTION
When a project has multi lsp clients, the status line's lsp status just fetches the first one'name which is not correct exactly.

And this PR fix the bug.