### PR TITLE
fix: show all lsp of mulit-lsps workspace

### DIFF
--- a/lua/ui/statusline.lua
+++ b/lua/ui/statusline.lua
@@ -149,13 +149,18 @@ end
 
 M.LSP_status = function()
    local clients = vim.lsp.get_active_clients()
-   local name = false
+   local names = {}
    for _, client in ipairs(clients) do
       if client.attached_buffers[vim.api.nvim_get_current_buf()] then
-         name = client.name
-         break
+         table.insert(names, client.name)
       end
    end
+  
+   local name = false
+   if names ~= {} then
+      name = table.concat(names, '/')
+   end
+   
    local content = name and "   LSP ~ " .. name .. " " or false
    return content and ("%#St_LspStatus#" .. content) or ""
 end


### PR DESCRIPTION
I don't use nvchad, but I copy codes from nvchad, and find this bug. Here is my function:

```lua
M.LSP_status = function()
    local clients = vim.lsp.get_active_clients()
    local id = vim.api.nvim_get_current_buf()
    local names = {}
    for _, client in ipairs(clients) do
        if client.name ~= 'null-ls' and client.name ~= 'copilot' and client.attached_buffers[id] then
            table.insert(names, client.name)
        end
    end

    return table.concat(names, '/')
end
```
For a multi-lsps workspace, it just like:

![图片](https://user-images.githubusercontent.com/42114817/173792534-024abd58-0fbc-496a-9758-fdd00974ad33.png)

