### PR TITLE
feature: make override can be a function

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -148,6 +148,10 @@ end
 M.load_override = function(default_table, plugin_name)
    local user_table = M.load_config().plugins.override[plugin_name]
 
+   if type(user_table) == "function" then
+      user_table = user_table()
+   end
+
    if type(user_table) == "table" then
       default_table = merge_tb("force", default_table, user_table)
    else


### PR DESCRIPTION
so we can use `require` even though it been lazy load like this.
```lua
local function override_cmp()
  local cmp = require 'cmp'
  return {
    mapping = {
      ['<C-k>'] = cmp.mapping.select_prev_item(),
      ['<C-j>'] = cmp.mapping.select_next_item(),
      ["<Tab>"] = cmp.mapping(function(fallback)
        local copilot_keys = vim.fn['copilot#Accept']()
        if copilot_keys ~= '' and type(copilot_keys) == 'string' then
          vim.api.nvim_feedkeys(copilot_keys, 'i', true)
        elseif cmp.visible() then
          cmp.select_next_item()
        elseif require("luasnip").expand_or_jumpable() then
          vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-expand-or-jump", true, true, true), "")
        else
          fallback()
        end
      end, {
         "i",
         "s",
      }),
    }
  }
end

M.override = {
  ["hrsh7th/nvim-cmp"] = override_cmp,
}

```
#1201 