### PR TITLE
Add mapping for new floating term

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -308,6 +308,13 @@ M.nvterm = {
 
       -- new
 
+      ["<leader>i"] = {
+         function()
+            require("nvterm.terminal").toggle "float"
+         end,
+         "   new floating term",
+      },
+
       ["<leader>h"] = {
          function()
             require("nvterm.terminal").new "horizontal"


### PR DESCRIPTION
Alt key is not friendly in macOS