### PR TITLE
Fix Plugin Override Function Capabilities

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -151,7 +151,9 @@ M.load_override = function(default_table, plugin_name)
 
    if type(user_table) == "function" then
       user_table = user_table()
-   elseif type(user_table) == "table" then
+   end
+
+   if type(user_table) == "table" then
       default_table = merge_tb("force", default_table, user_table)
    else
       default_table = default_table


### PR DESCRIPTION
In order to ensure that plugin configuration that is overridden with a
function instead of a table is still merged with the default plugin
configuration, this commit splits up the if/elseif/else statement in
lua/core/utils.lua.

This is necessary as we want to take the resulting table returned from
the override function and merge it with the default_table before setting
up the plugin.

Fixes [this issue](https://github.com/NvChad/NvChad/issues/1239)