### PR TITLE
added missing brackets

### DIFF
--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -6,7 +6,7 @@ M.autopairs = function()
    local present1, autopairs = pcall(require, "nvim-autopairs")
    local present2, cmp = pcall(require, "cmp")
 
-   if not present1 and present2 then
+   if not (present1 and present2) then
       return
    end
 


### PR DESCRIPTION
In configuration for nvim-autopairs code could run even if there was a missing plugin.
This code shows the problem

```
present1 = true
present2 = false

if not present1 and present2 then
  print "false detected"
else
  print "false not detected"
end
```
When you run this code it will print "false not detected".
