### PR TITLE
Minor syntax fix

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -59,10 +59,10 @@ local options = {
       ["<C-f>"] = cmp.mapping.scroll_docs(4),
       ["<C-Space>"] = cmp.mapping.complete(),
       ["<C-e>"] = cmp.mapping.close(),
-      ["<CR>"] = cmp.mapping.confirm {
+      ["<CR>"] = cmp.mapping.confirm({
          behavior = cmp.ConfirmBehavior.Insert,
          select = true,
-      },
+      }),
       ["<Tab>"] = cmp.mapping(function(fallback)
          if cmp.visible() then
             cmp.select_next_item()


### PR DESCRIPTION
I was messing around with configurations of the cmp.nvim plugin. And it seems that the mapping for Confirm won't actually use the given value of `select=` until I put parenthesis around blocks.
I'm quite new to Lua script so I'm not entirely sure if this is intentional or not.