### PR TITLE
feat(nvim-tree): enable adaptize size

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -23,6 +23,7 @@ local options = {
       update_cwd = false,
    },
    view = {
+      adaptive_size = true,
       side = "left",
       width = 25,
       hide_root_folder = true,


### PR DESCRIPTION
Signed-off-by: Höhl, Lukas <lukas.hoehl@accso.de>

Nvim-tree introduced an option to dynamically increase and shrink the size of the drawn tree.  \
See https://github.com/kyazdani42/nvim-tree.lua/pull/1293.

I think this is something, that nearly everyone wants in their default config, which is why this PR enables this feature in the default config of nvim-tree.
