### PR TITLE
feat(nvimtree): enable filesystem watcher

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -32,6 +32,9 @@ local options = {
       enable = false,
       ignore = true,
    },
+   filesystem_watchers = {
+      enable = true,
+    },
    actions = {
       open_file = {
          resize_window = true,


### PR DESCRIPTION
Enables the option for nvim-tree to automatically sync on filesystem changes.

For more information, see https://github.com/kyazdani42/nvim-tree.lua/blob/7a795d78fa2a102de197e81b85f5b1e6b5f366a3/doc/nvim-tree-lua.txt#L508

Signed-off-by: Höhl, Lukas <lukas.hoehl@accso.de>