### PR TITLE
stylua: Replace `no_call_parentheses` with `call_parentheses`

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -3,4 +3,4 @@ line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 3
 quote_style = "AutoPreferDouble"
-no_call_parentheses = true
+call_parentheses = "None"


### PR DESCRIPTION
The option has changed since https://github.com/JohnnyMorganz/StyLua/pull/330

Updating the other repos as well:
https://github.com/NvChad/nvim-colorizer.lua/pull/5
https://github.com/NvChad/nvterm/pull/14
https://github.com/NvChad/base46/pull/90
https://github.com/NvChad/extensions/pull/31