### PR TITLE
signatureHelp: don't capture focus

### DIFF
--- a/lua/ui/lsp.lua
+++ b/lua/ui/lsp.lua
@@ -22,6 +22,8 @@ vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
 })
 vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
    border = "single",
+   focusable = false,
+   relative = "cursor",
 })
 
 -- suppress error messages from lang servers


### PR DESCRIPTION
Re add focusable and cursor opts to signatureHelp windows.

This options were removed with "clean config | fix (#1225) (#1226)" (9dca3e) and since then the signature help randomly takes focus.

These options are enough to avoid <leader>ls float window to not be focusable, and thus I expect the signatureHelp window also won't be, but since I haven't found a repeatable way to reproduce the issue I can't be sure.