### PR TITLE
fix: meson.nvim override typo

### DIFF
--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -31,7 +31,7 @@ local options = {
   max_concurrent_installers = 10,
 }
 
-options = require("core.utils").load_override(options, "williamboman/mason")
+options = require("core.utils").load_override(options, "williamboman/mason.nvim")
 
 vim.api.nvim_create_user_command("MasonInstallAll", function()
   vim.cmd("MasonInstall " .. table.concat(options.ensure_installed, " "))


### PR DESCRIPTION
It should be `williamboman/mason.nvim` instead of `williamboman/mason`.