### PR TITLE
fix(options): don't set `did_load_filetypes` in neovim nightly

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -1,15 +1,19 @@
 local opt = vim.opt
 local g = vim.g
 local config = require("core.utils").load_config()
+local vim_version = vim.version()
 
 g.nvchad_theme = config.ui.theme
 g.toggle_theme_icon = "   "
 g.transparency = config.ui.transparency
 g.theme_switcher_loaded = false
 
--- use filetype.lua instead of filetype.vim
-g.did_load_filetypes = 0
-g.do_filetype_lua = 1
+-- use filetype.lua instead of filetype.vim. it's enabled by default in neovim 0.8 (nightly)
+if vim_version.minor < 8 then
+  g.did_load_filetypes = 0
+  g.do_filetype_lua = 1
+end
+
 
 opt.laststatus = 3 -- global statusline
 opt.showmode = false


### PR DESCRIPTION
[Lua filetype detection is enabled by default in neovim nightly](https://github.com/neovim/neovim/pull/19216) so we don't need those two options. The reason we can't simply override them in `custom/init.lua` is that setting any value to `did_load_filetypes`, completely disables filetype detection (and therefore syntax highlighting) and this may confuse people that use neovim nightly. I know NvChad doesn't officially support neovim nightly but people may want to try it to see the new features and this PR makes their life easier. Also, you do a similar thing in `plugins/configs/lspconfig.lua` so I thought it's ok :)