### PR TITLE
Fix windows env path separator

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -1,5 +1,6 @@
 -- add binaries installed by mason.nvim to path
-vim.env.PATH = vim.env.PATH .. ":" .. vim.fn.stdpath "data" .. "/mason/bin"
+local is_windows = vim.loop.os_uname().sysname == "Windows_NT"
+vim.env.PATH = vim.env.PATH .. (is_windows and ";" or ":") .. vim.fn.stdpath "data" .. "/mason/bin"
 
 -- commands
 vim.cmd "silent! command! NvChadUpdate lua require('nvchad').update_nvchad()"


### PR DESCRIPTION
Fix: mason installed binaries path appended to env.PATH when os is windows, the env path separator is ";".