### PR TITLE
fix(0.8): :bug: update session data dir in neovim nightly

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -14,7 +14,6 @@ if g.vim_version < 8 then
   g.do_filetype_lua = 1
 end
 
-
 opt.laststatus = 3 -- global statusline
 opt.showmode = false
 
@@ -105,6 +104,6 @@ end
 
 -- set shada path
 vim.schedule(function()
-  vim.opt.shadafile = vim.fn.expand "$HOME" .. "/.local/share/nvim/shada/main.shada"
+  vim.opt.shadafile = vim.fn.stdpath(g.vim_version > 7 and "state" or "data") .. "/shada/main.shada"
   vim.cmd [[ silent! rsh ]]
 end)


### PR DESCRIPTION
Nvim now stores "session data" (shada, persistent undo, ...) in $XDG_STATE_HOME (~/.local/state)