### PR TITLE
feat(keymaps): add keymaps to move in the wildmenu

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -74,6 +74,11 @@ M.general = {
     -- https://vim.fandom.com/wiki/Replace_a_word_with_yanked_text#Alternative_mapping_for_paste
     ["p"] = { 'p:let @+=@0<CR>:let @"=@0<CR>', opts = { silent = true } },
   },
+
+  c = {
+    ["<C-j>"] = { "<C-n>", " select next" },
+    ["<C-k>"] = { "<C-p>", " select previous" },
+  },
 }
 
 M.tabufline = {


### PR DESCRIPTION
These keymaps select the next/previous item in the wildmenu with `C-j` and `C-k`. I think these are more intuitive than `C-n` and `C-p` (default keymaps) and kinda in line with the keymaps that already exist (`C-j/k` is also used to move between windows and navigate within insert mode).