### PR TITLE
'blankline' fix filetype_exclude mason

### DIFF
--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -49,7 +49,7 @@ M.blankline = function()
       "lspinfo",
       "TelescopePrompt",
       "TelescopeResults",
-      "Mason",
+      "mason",
       "",
     },
     buftype_exclude = { "terminal" },


### PR DESCRIPTION
with a capital letter it doesn't work

![screenshot](https://user-images.githubusercontent.com/87767572/183357041-c7df65a5-2243-4a7a-99e3-c47d780fa804.png)
