### PR TITLE
fix: make paddings in the alpha layout can be overrided

### DIFF
--- a/lua/plugins/configs/alpha.lua
+++ b/lua/plugins/configs/alpha.lua
@@ -34,6 +34,11 @@ local function button(sc, txt, keybind)
   }
 end
 
+-- dynamic header padding
+local fn = vim.fn
+local marginTopPercent = 0.3
+local headerPadding = fn.max { 2, fn.floor(fn.winheight(0) * marginTopPercent) }
+
 local options = {
 
   header = {
@@ -71,20 +76,18 @@ local options = {
       spacing = 1,
     },
   },
+
+  headerPaddingTop = { type = "padding", val = headerPadding },
+  headerPaddingBottom = { type = "padding", val = 2 },
 }
 
 options = require("core.utils").load_override(options, "goolord/alpha-nvim")
 
--- dynamic header padding
-local fn = vim.fn
-local marginTopPercent = 0.3
-local headerPadding = fn.max { 2, fn.floor(fn.winheight(0) * marginTopPercent) }
-
 alpha.setup {
   layout = {
-    { type = "padding", val = headerPadding },
+    options.headerPaddingTop,
     options.header,
-    { type = "padding", val = 2 },
+    options.headerPaddingBottom,
     options.buttons,
   },
   opts = {},


### PR DESCRIPTION
users can adjust the padding between the top and the header, or the header and buttons.