### PR TITLE
Resize panes when vim window is resized

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -85,3 +85,9 @@ autocmd("BufDelete", {
     end
   end,
 })
+
+-- Auto resize panes
+autocmd("VimResized", {
+  pattern = "*",
+  command = "tabdo wincmd =",
+})


### PR DESCRIPTION
I always use nvim in tmux and I often change my panes size.

# Before

![CleanShot 2022-08-19 at 18 17 04](https://user-images.githubusercontent.com/541937/185688326-8553d543-564a-48a1-a48c-aa24834bd5d6.gif)

# After

![CleanShot 2022-08-19 at 18 21 10](https://user-images.githubusercontent.com/541937/185688379-7160198e-aae7-4f36-9b8a-5548fb1298c7.gif)


