### PR TITLE
fix: Windows User cannot load gitsigns

### DIFF
--- a/lua/core/lazy_load.lua
+++ b/lua/core/lazy_load.lua
@@ -79,7 +79,7 @@ M.mason_cmds = {
 M.gitsigns = function()
   autocmd({ "BufRead" }, {
     callback = function()
-      vim.fn.system("git rev-parse 2>/dev/null " .. vim.fn.expand "%:p:h")
+      vim.fn.system("git rev-parse " .. vim.fn.expand "%:p:h")
       if vim.v.shell_error == 0 then
         vim.schedule(function()
           require("packer").loader "gitsigns.nvim"


### PR DESCRIPTION
As Windows Syntax for Pipe is different, remove Pipe completely to make sure Gitsigns can be loaded when using on Windows Powershell
