### PR TITLE
fix: gitsigns not loading anymore

### DIFF
--- a/lua/core/lazy_load.lua
+++ b/lua/core/lazy_load.lua
@@ -79,7 +79,7 @@ M.mason_cmds = {
 M.gitsigns = function()
   autocmd({ "BufRead" }, {
     callback = function()
-      vim.fn.system("git rev-parse" .. vim.fn.expand "%:p:h")
+      vim.fn.system("git rev-parse" .. " " .. vim.fn.expand "%:p:h")
       if vim.v.shell_error == 0 then
         vim.schedule(function()
           require("packer").loader "gitsigns.nvim"

--- a/lua/core/lazy_load.lua
+++ b/lua/core/lazy_load.lua
@@ -79,7 +79,7 @@ M.mason_cmds = {
 M.gitsigns = function()
   autocmd({ "BufRead" }, {
     callback = function()
-      vim.fn.system("git rev-parse" .. " " .. vim.fn.expand "%:p:h")
+      vim.fn.system("git rev-parse " .. vim.fn.expand "%:p:h")
       if vim.v.shell_error == 0 then
         vim.schedule(function()
           require("packer").loader "gitsigns.nvim"


### PR DESCRIPTION
As siduck removes the space from `vim.fn.system`, now the command is unusable.   
Re-add the space to make it work again