### PR TITLE
remove gitsigns autocmd on gitsigns load

### DIFF
--- a/lua/core/lazy_load.lua
+++ b/lua/core/lazy_load.lua
@@ -78,9 +78,11 @@ M.mason_cmds = {
 
 M.gitsigns = function()
   autocmd({ "BufRead" }, {
+    group = vim.api.nvim_create_augroup("GitSignsLazyLoad", { clear = true }),
     callback = function()
       vim.fn.system("git rev-parse " .. vim.fn.expand "%:p:h")
       if vim.v.shell_error == 0 then
+        vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
         vim.schedule(function()
           require("packer").loader "gitsigns.nvim"
         end)


### PR DESCRIPTION
Rn, even after loading gitsigns, we still have an autocmd that checks whether gitsigns is loaded or not, which is unnecessary.

This PR adds an augroup to that autocmd to stop the above from happening