### PR TITLE
fix: Added missing key triggers for which-key's sub-plugins

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -195,7 +195,7 @@ local plugins = {
   ["folke/which-key.nvim"] = {
     disable = true,
     module = "which-key",
-    keys = "<leader>",
+    keys = { "<leader>", "\"", "'", "`" },
     config = function()
       require "plugins.configs.whichkey"
     end,


### PR DESCRIPTION
The which-keys plugin: https://github.com/folke/which-key.nvim#Plugins has other sub-plugins enabled by default including `Marks` and `Registers`.

`Marks` is triggered by the `` ` `` or `'` keys, and `Registers` is triggered by the " key. Note that neither of these keys require `<leader>` to be pressed, which is how the `which-key` plugin (if enabled) is lazy loaded in for now.

This leads to a strange behaviour where e.g. `"` or `'` only trigger the expected behaviour after `<leader>` is pressed at least once. To fix this I've added the aforementioned keys as eligible triggers to load `which-key` in.