### PR TITLE
feat: add buffer mapping for gitsigns

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -404,4 +404,137 @@ M.blankline = {
   },
 }
 
+M.gitsigns = {
+  plugin = true,
+
+  n = {
+    -- Navigation
+    ["]c"] = {
+      function()
+        if vim.wo.diff then
+          return "]c"
+        end
+        vim.schedule(function()
+          require("gitsigns").next_hunk()
+        end)
+        return "<Ignore>"
+      end,
+      "Jump to next hunk",
+      opts = { expr = true },
+    },
+    ["[c"] = {
+      function()
+        if vim.wo.diff then
+          return "[c"
+        end
+        vim.schedule(function()
+          require("gitsigns").prev_hunk()
+        end)
+        return "<Ignore>"
+      end,
+      "Jump to prev hunk",
+      opts = { expr = true },
+    },
+
+    -- Actions
+    ["<leader>hs"] = {
+      function()
+        require("gitsigns").stage_hunk()
+      end,
+    "Stage hunk",
+    },
+    ["<leader>hr"] = {
+      function()
+        require("gitsigns").reset_hunk()
+      end,
+      "Reset hunk",
+    },
+    ["<leader>hS"] = {
+      function()
+        require("gitsigns").stage_buffer()
+      end,
+      "Stage buffer",
+    },
+    ["<leader>hu"] = {
+      function()
+        require("gitsigns").undo_stage_hunk()
+      end,
+      "Undo stage hunk",
+    },
+    ["<leader>hR"] = {
+      function()
+        require("gitsigns").reset_buffer()
+      end,
+      "Reset buffer",
+    },
+    ["<leader>hp"] = {
+      function()
+        require("gitsigns").preview_hunk()
+      end,
+      "Preview hunk",
+    },
+    ["<leader>hb"] = {
+      function()
+        package.loaded.gitsigns.blame_line { full = true }
+      end,
+      "Blame line",
+    },
+    ["<leader>tb"] = {
+      function()
+        require("gitsigns").toggle_current_line_blame()
+      end,
+      "Toggle current line blame",
+    },
+    ["<leader>td"] = {
+      function()
+        require("gitsigns").toggle_deleted()
+      end,
+      "Toggle deleted",
+    },
+    ["<leader>hd"] = {
+      function()
+        require("gitsigns").diffthis()
+      end,
+      "Diff against the index",
+    },
+    ["<leader>hD"] = {
+      function()
+        require("gitsigns").diffthis "~"
+      end,
+      "Diff against the last commit",
+    },
+  },
+  v = {
+    -- Actions
+    ["<leader>hs"] = {
+      function()
+        require("gitsigns").stage_hunk()
+      end,
+      "Stage hunk",
+    },
+    ["<leader>hr"] = {
+      function ()
+        require("gitsigns").reset_hunk()
+      end,
+      "Reset hunk",
+    },
+  },
+  x = {
+    ["ih"] = {
+      function ()
+        require("gitsigns").select_hunk()
+      end,
+      "Reset hunk",
+    },
+  },
+  o = {
+    ["ih"] = {
+      function ()
+        require("gitsigns").select_hunk()
+      end,
+      "Reset hunk",
+    },
+  },
+}
+
 return M

--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local load_override = require("core.utils").load_override
+local utils = require "core.utils"
 
 M.autopairs = function()
   local present1, autopairs = pcall(require, "nvim-autopairs")
@@ -145,6 +146,9 @@ M.gitsigns = function()
       topdelete = { hl = "DiffDelete", text = "‾", numhl = "GitSignsDeleteNr" },
       changedelete = { hl = "DiffChangeDelete", text = "~", numhl = "GitSignsChangeNr" },
     },
+    on_attach = function (bufnr)
+      utils.load_mappings("gitsigns", { buffer = bufnr })
+    end
   }
 
   options = load_override(options, "lewis6991/gitsigns.nvim")


### PR DESCRIPTION
Features Added:
- Buffer mappings for gitsigns

Reasoning:
The default settings from [ewis6991/gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim#keymaps) does not include a default mapping for all gitsigns actions, also NvChad does not include this as well.