### PR TITLE
config(cmp): correcting completeopt setup

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -6,7 +6,7 @@ end
 
 require("base46").load_highlight "cmp"
 
-vim.opt.completeopt = "menuone,noselect"
+vim.o.completeopt = "menu,menuone,noselect"
 
 local function border(hl_name)
   return {


### PR DESCRIPTION
From the neovim doc,
In Vimscript:
    `set completeopt=menu,menuone,noselect`

In Lua using `vim.o`:
    `vim.o.completeopt = 'menu,menuone,noselect'`

In Lua using `vim.opt`:
    `vim.opt.completeopt = { 'menu', 'menuoune', 'noselect' }`