### PR TITLE
Add coc-settings.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ plugin
 custom
 spell
 ftplugin
+coc-settings.json


### PR DESCRIPTION
If the user decides to install coc.nvim, he/she needs to create a `coc-settings.json` in the root of `nvim` (`:CocConfig` command). Since NvChad does not ship with coc.nvim, the file is exclusively customized and should be ignored.