### PR TITLE
Add .luarc.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ custom
 spell
 ftplugin
 coc-settings.json
+.luarc.json


### PR DESCRIPTION
Using `coc-lua` with `coc.nvim` will produce a `.luarc.json` when editing own custom configs that should be excluded from NvChad, since NvChad does not maintain its own `.luarc.json`