### PR TITLE
feat: allow overwrite alpha buttons

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -189,4 +189,32 @@ M.packer_sync = function(...)
   end
 end
 
+M.alpha_button = function (sc, txt, keybind)
+  local sc_ = sc:gsub("%s", ""):gsub("SPC", "<leader>")
+
+  local opts = {
+    position = "center",
+    text = txt,
+    shortcut = sc,
+    cursor = 5,
+    width = 36,
+    align_shortcut = "right",
+    hl = "AlphaButtons",
+  }
+
+  if keybind then
+    opts.keymap = { "n", sc_, keybind, { noremap = true, silent = true } }
+  end
+
+  return {
+    type = "button",
+    val = txt,
+    on_press = function()
+      local key = vim.api.nvim_replace_termcodes(sc_, true, false, true) or ""
+      vim.api.nvim_feedkeys(key, "normal", false)
+    end,
+    opts = opts,
+  }
+end
+
 return M

--- a/lua/plugins/configs/alpha.lua
+++ b/lua/plugins/configs/alpha.lua
@@ -1,3 +1,4 @@
+local button = require("core.utils").alpha_button
 local present, alpha = pcall(require, "alpha")
 
 if not present then
@@ -5,34 +6,6 @@ if not present then
 end
 
 require("base46").load_highlight "alpha"
-
-local function button(sc, txt, keybind)
-  local sc_ = sc:gsub("%s", ""):gsub("SPC", "<leader>")
-
-  local opts = {
-    position = "center",
-    text = txt,
-    shortcut = sc,
-    cursor = 5,
-    width = 36,
-    align_shortcut = "right",
-    hl = "AlphaButtons",
-  }
-
-  if keybind then
-    opts.keymap = { "n", sc_, keybind, { noremap = true, silent = true } }
-  end
-
-  return {
-    type = "button",
-    val = txt,
-    on_press = function()
-      local key = vim.api.nvim_replace_termcodes(sc_, true, false, true) or ""
-      vim.api.nvim_feedkeys(key, "normal", false)
-    end,
-    opts = opts,
-  }
-end
 
 -- dynamic header padding
 local fn = vim.fn


### PR DESCRIPTION
Why:

Alpha dashboard provides a cool way to define shortcuts to start using neovim,this feature allows to NvChad overwrite mappings according user needs in the initial dashboard.

This solve the needed from this thread: https://t.me/DE_WM/542552

Just right now the default mapping from NvChad has some conflicts, for example with the bookmarks ` <Leader>bm`  is omitted in favor of  ` <Leader>b` for new buffer, and marks are a good way to set a bookmark for large project and big modules, so this PR allow to override the dashboard buttons just by requiring ` local buttons = require("core.utils").alpha_button`  in the user namespace that allow overwrite default NvChad settings for Alpha dashboard