### PR TITLE
Fix next diagnostic key mapping

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -213,7 +213,7 @@ M.lspconfig = {
       "goto prev",
     },
 
-    ["d]"] = {
+    ["]d"] = {
       function()
         vim.diagnostic.goto_next()
       end,


### PR DESCRIPTION
Consistent with vim's convention, may be this key mapping should be `]d`?