### PR TITLE
ensure errors arent silently swallowed in custom chadrc if exists

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -3,9 +3,12 @@ local merge_tb = vim.tbl_deep_extend
 
 M.load_config = function()
   local config = require "core.default_config"
-  local chadrc_exists, chadrc = pcall(require, "custom.chadrc")
+
+  -- nvim_get_runtime_file always uses forward slashes regardless of platform
+  local chadrc_exists = vim.api.nvim_get_runtime_file('lua/custom/chadrc.lua', false)[1]
 
   if chadrc_exists then
+    local chadrc = require  "custom.chadrc"
     -- merge user config if it exists and is a table; otherwise display an error
     if type(chadrc) == "table" then
       config.mappings = M.remove_disabled_keys(chadrc.mappings, config.mappings)

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -4,18 +4,13 @@ local merge_tb = vim.tbl_deep_extend
 M.load_config = function()
   local config = require "core.default_config"
 
-  -- nvim_get_runtime_file always uses forward slashes regardless of platform
-  local chadrc_exists = vim.api.nvim_get_runtime_file('lua/custom/chadrc.lua', false)[1]
+  local chadrc_path = vim.api.nvim_get_runtime_file("lua/custom/chadrc.lua", false)[1]
 
-  if chadrc_exists then
-    local chadrc = require  "custom.chadrc"
-    -- merge user config if it exists and is a table; otherwise display an error
-    if type(chadrc) == "table" then
-      config.mappings = M.remove_disabled_keys(chadrc.mappings, config.mappings)
-      config = merge_tb("force", config, chadrc) or {}
-    else
-      error "chadrc must return a table!"
-    end
+  if chadrc_path then
+    local chadrc = dofile(chadrc_path)
+
+    config.mappings = M.remove_disabled_keys(chadrc.mappings, config.mappings)
+    config = merge_tb("force", config, chadrc)
   end
 
   config.mappings.disabled = nil


### PR DESCRIPTION
Avoids using pcall as a general catch all so that errors in one's custom chadrc aren't silently swallowed. 

Addresses issue #1690

Due credit to @ii14 for approach here.. 