### PR TITLE
Fix mkdir on windows

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,7 +18,7 @@ if fn.empty(fn.glob(install_path)) > 0 then
   print "Cloning packer .."
   fn.system { "git", "clone", "--depth", "1", "https://github.com/wbthomason/packer.nvim", install_path }
 
-  os.execute("mkdir -p " .. vim.g.base46_cache)
+  vim.fn.mkdir(vim.g.base46_cache, "p")
 
   -- install plugins + compile their configs
   vim.cmd "packadd packer.nvim"


### PR DESCRIPTION
`mkdir -p` is assuming all users are using Unix, use builtin `vim.fn.mkdir` instead