### PR TITLE
Fix statusline toggle when re-visiting the dashboard

### DIFF
--- a/lua/plugins/configs/alpha.lua
+++ b/lua/plugins/configs/alpha.lua
@@ -97,14 +97,26 @@ alpha.setup {
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "alpha",
   callback = function()
-    -- store current statusline value and use that
-    local old_laststatus = vim.opt.laststatus
-    vim.api.nvim_create_autocmd("BufUnload", {
-      buffer = 0,
-      callback = function()
-        vim.opt.laststatus = old_laststatus
-      end,
-    })
+    -- store initial statusline value to be used later
+    if type(vim.g.nvchad_vim_laststatus) == "nil" then
+      vim.g.nvchad_vim_laststatus = vim.opt.laststatus._value
+    end
+
+    -- Remove statusline since we have just loaded into an "alpha" filetype (i.e. dashboard)
     vim.opt.laststatus = 0
+
+    vim.api.nvim_create_autocmd({ "TabEnter", "BufLeave" }, {
+      callback = function()
+        local current_type = vim.bo.filetype
+        if current_type == "alpha" or #current_type == 0 then
+          -- Switched to alpha or unknown filetype
+          vim.opt.laststatus = 0
+        else
+          -- Switched to any other filetype
+          vim.opt.laststatus = vim.g.nvchad_vim_laststatus
+        end
+      end
+    })
+
   end,
 })

--- a/lua/plugins/configs/alpha.lua
+++ b/lua/plugins/configs/alpha.lua
@@ -98,7 +98,7 @@ vim.api.nvim_create_autocmd("FileType", {
   pattern = "alpha",
   callback = function()
     -- store initial statusline value to be used later
-    if type(vim.g.nvchad_vim_laststatus) == "nil" then
+    if not vim.g.nvchad_vim_laststatus then
       vim.g.nvchad_vim_laststatus = vim.opt.laststatus._value
     end
 


### PR DESCRIPTION
At any time you can run the `:Alpha` command to revisit the dashboard, but this causes issues with the statusline.

One example is if you open the dashboard in a new tab and then open more new files in another new tab, especially without closing the dashboard, the autocmd's set up in the config don't toggle the statusline on and off at the right times.

This new revised logic checks the file type each time a buffer is departed from, or a tab is arrived at. It also stores the original value for `laststatus` in a unique `vim.g` location, and makes sure that is not overwritten.