### PR TITLE
fix nvim-tree's reporitory name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ spell
 ftplugin
 coc-settings.json
 .luarc.json
+lazy-lock.json

--- a/init.lua
+++ b/init.lua
@@ -1,22 +1,6 @@
-vim.defer_fn(function()
-  pcall(require, "impatient")
-end, 0)
-
 require "core"
 require "core.options"
-
-pcall(function()
-  loadfile(vim.g.base46_cache .. "bg")()
-end)
-
--- setup packer + plugins
-local fn = vim.fn
-local install_path = fn.stdpath "data" .. "/site/pack/packer/opt/packer.nvim"
-
-if fn.empty(fn.glob(install_path)) > 0 then
-  require("core.bootstrap").chadrc_template()
-  require("core.bootstrap").packer(install_path)
-end
+require("core.utils").load_mappings()
 
 local custom_init_path = vim.api.nvim_get_runtime_file("lua/custom/init.lua", false)[1]
 
@@ -24,4 +8,18 @@ if custom_init_path then
   dofile(custom_init_path)
 end
 
-require("core.utils").load_mappings()
+-- bootstrap lazy.nvim!
+local lazypath = vim.fn.stdpath "data" .. "/lazy/lazy.nvim"
+
+if not vim.loop.fs_stat(lazypath) then
+  require("core.bootstrap").gen_chadrc_template()
+  require("core.bootstrap").lazy(lazypath)
+end
+
+vim.opt.rtp:prepend(lazypath)
+require "plugins"
+
+-- load compiled base46 themes
+loadfile(vim.g.base46_cache .. "bg")()
+loadfile(vim.g.base46_cache .. "defaults")()
+loadfile(vim.g.base46_cache .. "statusline")()

--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -4,7 +4,7 @@ M.lazy = function(install_path)
   print "Downloading lazy-lock.json file..."
 
   local config_branch = require("core.utils").load_config().options.nvChad.update_branch
-  local lazy_local_url = "https://raw.githubusercontent.com/NvChad/extensions/lazy-lock/" .. config_branch .. ".json "
+  local lazy_local_url = "https://raw.githubusercontent.com/NvChad/extensions/lazy-lock/" .. config_branch .. ".json"
 
   vim.fn.system { "curl", "-o", "lazy-lock.json", lazy_local_url }
 

--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -1,6 +1,14 @@
 local M = {}
 
 M.lazy = function(install_path)
+  print "Downloading lazy-lock.json file..."
+
+  local config_branch = require("core.utils").load_config().options.nvChad.update_branch
+
+ vim.cmd(
+    "!curl -o lazy-lock.json https://raw.githubusercontent.com/NvChad/extensions/lazy-lock/" .. config_branch .. ".json "
+  )
+
   print "Bootstrapping lazy.nvim .."
 
   vim.fn.system {

--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -4,10 +4,9 @@ M.lazy = function(install_path)
   print "Downloading lazy-lock.json file..."
 
   local config_branch = require("core.utils").load_config().options.nvChad.update_branch
+  local lazy_local_url = "https://raw.githubusercontent.com/NvChad/extensions/lazy-lock/" .. config_branch .. ".json "
 
- vim.cmd(
-    "!curl -o lazy-lock.json https://raw.githubusercontent.com/NvChad/extensions/lazy-lock/" .. config_branch .. ".json "
-  )
+  vim.fn.system { "curl", "-o", "lazy-lock.json", lazy_local_url }
 
   print "Bootstrapping lazy.nvim .."
 

--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -5,7 +5,7 @@ local M = {}
 M.options = {
   nvChad = {
     update_url = "https://github.com/NvChad/NvChad",
-    update_branch = "dev",
+    update_branch = "lazy",
   },
 }
 

--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -5,7 +5,7 @@ local M = {}
 M.options = {
   nvChad = {
     update_url = "https://github.com/NvChad/NvChad",
-    update_branch = "lazy",
+    update_branch = "v2.0",
   },
 }
 

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -38,17 +38,3 @@ autocmd("FileType", {
     vim.opt_local.buflisted = false
   end,
 })
-
--- wrap the PackerSync command to warn people before using it in NvChadSnapshots
-autocmd("VimEnter", {
-  callback = function()
-    vim.api.nvim_create_user_command("PackerSync", function(opts)
-      require "plugins"
-      require("core.utils").packer_sync(opts.fargs)
-    end, {
-      bang = true,
-      nargs = "*",
-      complete = require("packer").plugin_complete,
-    })
-  end,
-})

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -12,22 +12,6 @@ new_cmd("NvChadUpdate", function()
   require("nvchad").update_nvchad()
 end, {})
 
-new_cmd("NvChadSnapshotCreate", function()
-  require("nvchad").snap_create()
-end, {})
-
-new_cmd("NvChadSnapshotDelete", function()
-  require("nvchad").snap_delete()
-end, {})
-
-new_cmd("NvChadSnapshotCheckout", function()
-  require("nvchad").snap_checkout()
-end, {})
-
-new_cmd("NvChadUpdate", function()
-  require("nvchad").update_nvchad()
-end, {})
-
 -- autocmds
 local autocmd = vim.api.nvim_create_autocmd
 

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -11,6 +11,12 @@ M.general = {
     -- go to  beginning and end
     ["<C-b>"] = { "<ESC>^i", "beginning of line" },
     ["<C-e>"] = { "<End>", "end of line" },
+
+    -- navigate within insert mode
+    ["<C-h>"] = { "<Left>", "move left" },
+    ["<C-l>"] = { "<Right>", "move right" },
+    ["<C-j>"] = { "<Down>", "move down" },
+    ["<C-k>"] = { "<Up>", "move up" },
   },
 
   n = {

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -49,40 +49,6 @@ opt.whichwrap:append "<>[]hl"
 
 g.mapleader = " "
 
--- disable some builtin vim plugins
-local default_plugins = {
-  "2html_plugin",
-  "getscript",
-  "getscriptPlugin",
-  "gzip",
-  "logipat",
-  "netrw",
-  "netrwPlugin",
-  "netrwSettings",
-  "netrwFileHandlers",
-  "matchit",
-  "tar",
-  "tarPlugin",
-  "rrhelper",
-  "spellfile_plugin",
-  "vimball",
-  "vimballPlugin",
-  "zip",
-  "zipPlugin",
-  "tutor",
-  "rplugin",
-  "syntax",
-  "synmenu",
-  "optwin",
-  "compiler",
-  "bugreport",
-  "ftplugin",
-}
-
-for _, plugin in pairs(default_plugins) do
-  g["loaded_" .. plugin] = 1
-end
-
 local default_providers = {
   "node",
   "perl",

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -116,49 +116,12 @@ M.load_override = function(options_table, name)
   return merge_tb("force", options_table, plugin_options)
 end
 
-M.packer_sync = function(...)
-  local git_exists, git = pcall(require, "nvchad.utils.git")
-  local defaults_exists, defaults = pcall(require, "nvchad.utils.config")
-  local packer_exists, packer = pcall(require, "packer")
-
-  if git_exists and defaults_exists then
-    local current_branch_name = git.get_current_branch_name()
-
-    -- warn the user if we are on a snapshot branch
-    if current_branch_name:match(defaults.snaps.base_snap_branch_name .. "(.+)" .. "$") then
-      vim.api.nvim_echo({
-        { "WARNING: You are trying to use ", "WarningMsg" },
-        { "PackerSync" },
-        {
-          " on a NvChadSnapshot. This will cause issues if NvChad dependencies contain "
-            .. "any breaking changes! Plugin updates will not be included in this "
-            .. "snapshot, so they will be lost after switching between snapshots! Would "
-            .. "you still like to continue? [y/N]\n",
-          "WarningMsg",
-        },
-      }, false, {})
-
-      local ans = vim.trim(string.lower(vim.fn.input "-> "))
-
-      if ans ~= "y" then
-        return
-      end
-    end
-  end
-
-  if packer_exists then
-    packer.sync(...)
-  else
-    error "Packer could not be loaded!"
-  end
-end
-
 M.lazy_load = function(plugin)
   vim.api.nvim_create_autocmd({ "BufRead", "BufWinEnter", "BufNewFile" }, {
     group = vim.api.nvim_create_augroup("BeLazyOnFileOpen" .. plugin, {}),
     callback = function()
       local file = vim.fn.expand "%"
-      local condition = file ~= "NvimTree_1" and file ~= "[packer]" and file ~= ""
+      local condition = file ~= "NvimTree_1" and file ~= "[lazy]" and file ~= ""
 
       if condition then
         vim.api.nvim_del_augroup_by_name("BeLazyOnFileOpen" .. plugin)
@@ -166,14 +129,15 @@ M.lazy_load = function(plugin)
         -- dont defer for treesitter as it will show slow highlighting
         -- This deferring only happens only when we do "nvim filename"
         if plugin ~= "nvim-treesitter" then
-          vim.defer_fn(function()
-            require("packer").loader(plugin)
+          vim.schedule(function()
+            require("lazy").load { plugins = plugin }
+
             if plugin == "nvim-lspconfig" then
               vim.cmd "silent! do FileType"
             end
           end, 0)
         else
-          require("packer").loader(plugin)
+          require("lazy").load { plugins = plugin }
         end
       end
     end,

--- a/lua/plugins/configs/lazy_nvim.lua
+++ b/lua/plugins/configs/lazy_nvim.lua
@@ -1,0 +1,70 @@
+return {
+  defaults = {
+    lazy = true,
+  },
+
+  install = {
+    -- try to load one of these colorschemes when starting an installation during startup
+    colorscheme = { "nvchad" },
+  },
+
+  ui = {
+    icons = {
+      cmd = " ",
+      config = "",
+      event = "",
+      ft = " ",
+      init = " ",
+      import = " ",
+      keys = " ",
+      lazy = "鈴 ",
+      loaded = "",
+      not_loaded = "",
+      plugin = " ",
+      runtime = " ",
+      source = " ",
+      start = "",
+      task = "✔ ",
+      list = {
+        "●",
+        "➜",
+        "★",
+        "‒",
+      },
+    },
+  },
+
+  performance = {
+    rtp = {
+      disabled_plugins = {
+        "2html_plugin",
+        "tohtml",
+        "getscript",
+        "getscriptPlugin",
+        "gzip",
+        "logipat",
+        "netrw",
+        "netrwPlugin",
+        "netrwSettings",
+        "netrwFileHandlers",
+        "matchit",
+        "tar",
+        "tarPlugin",
+        "rrhelper",
+        "spellfile_plugin",
+        "vimball",
+        "vimballPlugin",
+        "zip",
+        "zipPlugin",
+        "tutor",
+        "rplugin",
+        "syntax",
+        "synmenu",
+        "optwin",
+        "compiler",
+        "bugreport",
+        "ftplugin",
+      },
+    },
+  },
+}

--- a/lua/plugins/configs/lazy_nvim.lua
+++ b/lua/plugins/configs/lazy_nvim.lua
@@ -10,27 +10,10 @@ return {
 
   ui = {
     icons = {
-      cmd = " ",
-      config = "",
-      event = "",
-      ft = " ",
-      init = " ",
-      import = " ",
-      keys = " ",
+      ft = "",
       lazy = "鈴 ",
       loaded = "",
       not_loaded = "",
-      plugin = " ",
-      runtime = " ",
-      source = " ",
-      start = "",
-      task = "✔ ",
-      list = {
-        "●",
-        "➜",
-        "★",
-        "‒",
-      },
     },
   },
 

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -4,14 +4,7 @@ if not present then
   return
 end
 
-vim.api.nvim_create_augroup("_mason", { clear = true })
-vim.api.nvim_create_autocmd("Filetype", {
-  pattern = "mason",
-  callback = function()
-    loadfile(vim.g.base46_cache .. "mason")()
-  end,
-  group = "_mason",
-})
+loadfile(vim.g.base46_cache .. "mason")()
 
 local options = {
   ensure_installed = { "lua-language-server" }, -- not an option from mason.nvim

--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -83,7 +83,7 @@ local options = {
 }
 
 -- check for any override
-options = require("core.utils").load_override(options, "kyazdani42/nvim-tree.lua")
+options = require("core.utils").load_override(options, "nvim-tree/nvim-tree.lua")
 vim.g.nvimtree_side = options.view.side
 
 nvimtree.setup(options)

--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -37,7 +37,7 @@ M.blankline = function()
     filetype_exclude = {
       "help",
       "terminal",
-      "packer",
+      "lazy",
       "lspinfo",
       "TelescopePrompt",
       "TelescopeResults",
@@ -76,6 +76,7 @@ M.colorizer = function()
       css = false, -- Enable all CSS features: rgb_fn, hsl_fn, names, RGB, RRGGBB
       css_fn = false, -- Enable all CSS *functions*: rgb_fn, hsl_fn
       mode = "background", -- Set the display mode.
+      tailwind = true, -- Enable tailwind colors
     },
   }
 
@@ -166,24 +167,6 @@ M.devicons = function()
 
     devicons.setup(options)
   end
-end
-
-M.packer_init = function()
-  return {
-    auto_clean = true,
-    compile_on_sync = true,
-    git = { clone_timeout = 6000 },
-    display = {
-      working_sym = "ﲊ",
-      error_sym = "✗ ",
-      done_sym = " ",
-      removed_sym = " ",
-      moved_sym = "",
-      open_fn = function()
-        return require("packer.util").float { border = "single" }
-      end,
-    },
-  }
 end
 
 return M

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -4,14 +4,14 @@ local plugins = {
 
   ["nvim-lua/plenary.nvim"] = {},
 
-  ["NvChad/extensions"] = { branch = "lazy" },
+  ["NvChad/extensions"] = { branch = "v2.0" },
 
   ["NvChad/base46"] = {
-    branch = "lazy",
+    branch = "v2.0",
   },
 
   ["NvChad/ui"] = {
-    branch = "lazy",
+    branch = "v2.0",
     lazy = false,
     config = function()
       require "nvchad_ui"
@@ -182,6 +182,11 @@ local plugins = {
     end,
   },
 }
+
+-- pin commits for all default plugins
+for _, value in pairs(plugins) do
+  value.pin = true
+end
 
 plugins = require("core.utils").merge_plugins(plugins)
 

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -150,7 +150,7 @@ local plugins = {
   },
 
   -- file managing , picker etc
-  ["kyazdani42/nvim-tree.lua"] = {
+  ["nvim-tree/nvim-tree.lua"] = {
     cmd = { "NvimTreeToggle", "NvimTreeFocus" },
     config = function()
       require "plugins.configs.nvimtree"

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -1,64 +1,40 @@
+-- All plugins have lazy=true by default,to load a plugin on startup just lazy=false
 -- List of all default plugins & their definitions
 local plugins = {
 
-  ["nvim-lua/plenary.nvim"] = { module = "plenary" },
+  ["nvim-lua/plenary.nvim"] = {},
 
-  ["lewis6991/impatient.nvim"] = {},
-
-  ["wbthomason/packer.nvim"] = {
-    cmd = {
-      "PackerSnapshot",
-      "PackerSnapshotRollback",
-      "PackerSnapshotDelete",
-      "PackerInstall",
-      "PackerUpdate",
-      "PackerSync",
-      "PackerClean",
-      "PackerCompile",
-      "PackerStatus",
-      "PackerProfile",
-      "PackerLoad",
-    },
-    config = function()
-      require "plugins"
-    end,
-  },
-
-  ["NvChad/extensions"] = { branch = "dev", module = { "telescope", "nvchad" } },
+  ["NvChad/extensions"] = { branch = "lazy" },
 
   ["NvChad/base46"] = {
-    module = "base46",
-    branch = "dev",
+    branch = "lazy",
   },
 
   ["NvChad/ui"] = {
-    branch = "dev",
+    branch = "lazy",
+    lazy = false,
     config = function()
-      pcall(require, "nvchad_ui")
+      require "nvchad_ui"
     end,
   },
 
   ["NvChad/nvterm"] = {
-    module = "nvterm",
     config = function()
       require "plugins.configs.nvterm"
     end,
-    setup = function()
+    init = function()
       require("core.utils").load_mappings "nvterm"
     end,
   },
 
   ["kyazdani42/nvim-web-devicons"] = {
-    after = "ui",
-    module = "nvim-web-devicons",
     config = function()
       require("plugins.configs.others").devicons()
     end,
   },
 
   ["lukas-reineke/indent-blankline.nvim"] = {
-    opt = true,
-    setup = function()
+    init = function()
       require("core.utils").lazy_load "indent-blankline.nvim"
       require("core.utils").load_mappings "blankline"
     end,
@@ -68,8 +44,7 @@ local plugins = {
   },
 
   ["NvChad/nvim-colorizer.lua"] = {
-    opt = true,
-    setup = function()
+    init = function()
       require("core.utils").lazy_load "nvim-colorizer.lua"
     end,
     config = function()
@@ -78,12 +53,10 @@ local plugins = {
   },
 
   ["nvim-treesitter/nvim-treesitter"] = {
-    module = "nvim-treesitter",
-    setup = function()
+    init = function()
       require("core.utils").lazy_load "nvim-treesitter"
     end,
     cmd = { "TSInstall", "TSBufEnable", "TSBufDisable", "TSEnable", "TSDisable", "TSModuleInfo" },
-
     run = ":TSUpdate",
     config = function()
       require "plugins.configs.treesitter"
@@ -93,7 +66,7 @@ local plugins = {
   -- git stuff
   ["lewis6991/gitsigns.nvim"] = {
     ft = "gitcommit",
-    setup = function()
+    init = function()
       -- load gitsigns only when a git file is opened
       vim.api.nvim_create_autocmd({ "BufRead" }, {
         group = vim.api.nvim_create_augroup("GitSignsLazyLoad", { clear = true }),
@@ -102,7 +75,7 @@ local plugins = {
           if vim.v.shell_error == 0 then
             vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
             vim.schedule(function()
-              require("packer").loader "gitsigns.nvim"
+              require("lazy").load { plugins = "gitsigns.nvim" }
             end)
           end
         end,
@@ -122,8 +95,7 @@ local plugins = {
   },
 
   ["neovim/nvim-lspconfig"] = {
-    opt = true,
-    setup = function()
+    init = function()
       require("core.utils").lazy_load "nvim-lspconfig"
     end,
     config = function()
@@ -132,46 +104,47 @@ local plugins = {
   },
 
   -- load luasnips + cmp related in insert mode only
-
-  ["rafamadriz/friendly-snippets"] = { },
-
   ["hrsh7th/nvim-cmp"] = {
-    module = { "cmp", "cmp_nvim_lsp" },
-    event = { "InsertEnter", "CmdlineEnter" }, -- for users that may use nvim-cmp-cmdline
+    event = "InsertEnter",
+    dependencies = {
+      {
+        -- snippet plugin
+        "L3MON4D3/LuaSnip",
+        dependencies = "rafamadriz/friendly-snippets",
+        config = function()
+          require("plugins.configs.others").luasnip()
+        end,
+      },
+
+      -- autopairing of (){}[] etc
+      {
+        "windwp/nvim-autopairs",
+        config = function()
+          require("plugins.configs.others").autopairs()
+        end,
+      },
+
+      -- cmp sources plugins
+      {
+        "saadparwaiz1/cmp_luasnip",
+        "hrsh7th/cmp-nvim-lua",
+        "hrsh7th/cmp-nvim-lsp",
+        "hrsh7th/cmp-buffer",
+        "hrsh7th/cmp-path",
+      },
+    },
+
     config = function()
       require "plugins.configs.cmp"
     end,
   },
 
-  ["L3MON4D3/LuaSnip"] = {
-    requires = "friendly-snippets",
-    after = "nvim-cmp",
-    config = function()
-      require("plugins.configs.others").luasnip()
-    end,
-  },
-
-  ["saadparwaiz1/cmp_luasnip"] = { after = "LuaSnip" },
-  ["hrsh7th/cmp-nvim-lua"] = { after = "cmp_luasnip" },
-  ["hrsh7th/cmp-nvim-lsp"] = { after = "cmp-nvim-lua" },
-  ["hrsh7th/cmp-buffer"] = { after = "cmp-nvim-lsp" },
-  ["hrsh7th/cmp-path"] = { after = "cmp-buffer" },
-
-  -- misc plugins
-  ["windwp/nvim-autopairs"] = {
-    after = "nvim-cmp",
-    config = function()
-      require("plugins.configs.others").autopairs()
-    end,
-  },
-
   ["numToStr/Comment.nvim"] = {
-    module = "Comment",
-    keys = { "gc", "gb" },
+    -- keys = { "gc", "gb" },
     config = function()
       require("plugins.configs.others").comment()
     end,
-    setup = function()
+    init = function()
       require("core.utils").load_mappings "comment"
     end,
   },
@@ -182,7 +155,7 @@ local plugins = {
     config = function()
       require "plugins.configs.nvimtree"
     end,
-    setup = function()
+    init = function()
       require("core.utils").load_mappings "nvimtree"
     end,
   },
@@ -192,35 +165,28 @@ local plugins = {
     config = function()
       require "plugins.configs.telescope"
     end,
-    setup = function()
+    init = function()
       require("core.utils").load_mappings "telescope"
     end,
   },
 
   -- Only load whichkey after all the gui
   ["folke/which-key.nvim"] = {
-    disable = true,
-    module = "which-key",
+    enabled = false,
     keys = { "<leader>", '"', "'", "`" },
     config = function()
       require "plugins.configs.whichkey"
     end,
-    setup = function()
+    init = function()
       require("core.utils").load_mappings "whichkey"
     end,
   },
 }
 
-local present, packer = pcall(require, "packer")
+plugins = require("core.utils").merge_plugins(plugins)
 
-if present then
-  -- Override with default plugins with user ones
-  plugins = require("core.utils").merge_plugins(plugins)
+-- load lazy.nvim options
+local lazy_config = require "plugins.configs.lazy_nvim"
+lazy_config = require("core.utils").load_override(lazy_config, "folke/lazy.nvim")
 
-  -- load packer init options
-  local init_options = require("plugins.configs.others").packer_init()
-  init_options = require("core.utils").load_override(init_options, "wbthomason/packer.nvim")
-
-  packer.init(init_options)
-  packer.startup { plugins }
-end
+require("lazy").setup(plugins, lazy_config)


### PR DESCRIPTION
The repository `kyazdani42/nvim-tree.lua` that NvChad is referencing doesn't exist. 
It causes error in NvChad at lunching Packer.nvim.

The repository has been moved to `nvim-tree/nvim-tree.lua`

[nvim-tree/nvim-tree.lua: A file explorer tree for neovim written in lua](https://github.com/nvim-tree/nvim-tree.lua)

So I have updated `kyazdani42/nvim-tree.lua` to `nvim-tree/nvim-tree.lua` in two files.
This change fixes packer.nvim.
I have confirmed that the error in packer.nvim disappears and nvim-tree works correctly after this changes.