### PR TITLE
fix wrong nvim-tree.lua reporitory name error

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -84,7 +84,7 @@ local options = {
 }
 
 -- check for any override
-options = require("core.utils").load_override(options, "kyazdani42/nvim-tree.lua")
+options = require("core.utils").load_override(options, "nvim-tree/nvim-tree.lua")
 vim.g.nvimtree_side = options.view.side
 
 nvimtree.setup(options)

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -170,7 +170,7 @@ local plugins = {
   },
 
   -- file managing , picker etc
-  ["kyazdani42/nvim-tree.lua"] = {
+  ["nvim-tree/nvim-tree.lua"] = {
     ft = "alpha",
     cmd = { "NvimTreeToggle", "NvimTreeFocus" },
     config = function()


### PR DESCRIPTION
Now packer.nvim  is outputting error in NvChad at startup from Packer.nvim.
Because the repository `kyazdani42/nvim-tree.lua` that NvChad is referencing doesn't exist.

The repository moved to `nvim-tree/nvim-tree.lua`
[nvim-tree/nvim-tree.lua: A file explorer tree for neovim written in lua](https://github.com/nvim-tree/nvim-tree.lua)

So I have updated `kyazdani42/nvim-tree.lua` to `nvim-tree/nvim-tree.lua` in two files.
This change fixes packer.nvim.
I confirmed that the error in packer.nvim disappears and nvim-tree works correctly after this changes.