### PR TITLE
【fix】 correct both of kyazdani42 repo into nvim-tree repo

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -84,7 +84,7 @@ local options = {
 }
 
 -- check for any override
-options = require("core.utils").load_override(options, "kyazdani42/nvim-tree.lua")
+options = require("core.utils").load_override(options, "nvim-tree/nvim-tree.lua")
 vim.g.nvimtree_side = options.view.side
 
 nvimtree.setup(options)

--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -162,7 +162,7 @@ M.devicons = function()
     require("base46").load_highlight "devicons"
 
     local options = { override = require("nvchad_ui.icons").devicons }
-    options = require("core.utils").load_override(options, "kyazdani42/nvim-web-devicons")
+    options = require("core.utils").load_override(options, "nvim-tree/nvim-web-devicons")
 
     devicons.setup(options)
   end

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -44,7 +44,7 @@ local plugins = {
     end,
   },
 
-  ["kyazdani42/nvim-web-devicons"] = {
+  ["nvim-tree/nvim-web-devicons"] = {
     after = "ui",
     module = "nvim-web-devicons",
     config = function()
@@ -170,7 +170,7 @@ local plugins = {
   },
 
   -- file managing , picker etc
-  ["kyazdani42/nvim-tree.lua"] = {
+  ["nvim-tree/nvim-tree.lua"] = {
     ft = "alpha",
     cmd = { "NvimTreeToggle", "NvimTreeFocus" },
     config = function()


### PR DESCRIPTION
`kyazdani42` repo moved to `nvim-tree` repo.
So NvChad nedd to change referencing repository.
NvChad is outputting error at startup from Packer.nvim.

I fix the two reporitory reference.
[nvim-tree/nvim-tree.lua: A file explorer tree for neovim written in lua](https://github.com/nvim-tree/nvim-tree.lua)
[nvim-tree/nvim-web-devicons: lua `fork` of vim-web-devicons for neovim](https://github.com/nvim-tree/nvim-web-devicons)

This change fixes Packer.nvim.
I confirmed that the error in Packer.nvim disappears and nvim-tree and nvim-web-decicons works correctly after this changes.