### PR TITLE
fix: nvim-tree deprecation notice (#1755)

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -13,7 +13,6 @@ local options = {
   },
   disable_netrw = true,
   hijack_netrw = true,
-  ignore_ft_on_setup = { "alpha" },
   hijack_cursor = true,
   hijack_unnamed_buffer_when_opening = false,
   update_cwd = true,


### PR DESCRIPTION
According to the wiki `ignore_ft_on_setup` is also deprecated, this solves the problem in #1755.

[https://github.com/nvim-tree/nvim-tree.lua/wiki/Open-At-Startup](https://github.com/nvim-tree/nvim-tree.lua/wiki/Open-At-Startup)