### PR TITLE
update nvim-tree option names

### DIFF
--- a/lua/plugins/configs/nvimtree.lua
+++ b/lua/plugins/configs/nvimtree.lua
@@ -9,10 +9,10 @@ local options = {
   hijack_netrw = true,
   hijack_cursor = true,
   hijack_unnamed_buffer_when_opening = false,
-  update_cwd = true,
+  sync_root_with_cwd = true,
   update_focused_file = {
     enable = true,
-    update_cwd = false,
+    update_root = false,
   },
   view = {
     adaptive_size = false,


### PR DESCRIPTION
follow the latest nvim-tree option names

- [update_cwd → sync_root_with_cwd](https://github.com/nvim-tree/nvim-tree.lua/blob/02fdc262eba188198a7deb2117b3b996e6763d65/doc/nvim-tree-lua.txt#L497) 
- [update_focused_file.update_cwd → update_focused_file.update_root](https://github.com/nvim-tree/nvim-tree.lua/blob/02fdc262eba188198a7deb2117b3b996e6763d65/doc/nvim-tree-lua.txt#L530)