### PR TITLE
Add cheatsheet.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ spell
 ftplugin
 coc-settings.json
 .luarc.json
+cheatsheet.txt


### PR DESCRIPTION
Currently, `cheatsheet.txt` is not added to the `.gitignore` file. This can cause issues. `cheatsheet.txt` is a file needed for [this](https://github.com/sudormrfbin/cheatsheet.nvim) plugin and unfortunately there isn't any option to change its path. This file should be excluded from the git repo, since NvChad doesn't maintain its own `cheatsheet.txt`.