### PR TITLE
Add lazy.nvim to workspace library

### DIFF
--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -51,6 +51,7 @@ require("lspconfig").lua_ls.setup {
           [vim.fn.expand "$VIMRUNTIME/lua"] = true,
           [vim.fn.expand "$VIMRUNTIME/lua/vim/lsp"] = true,
           [vim.fn.stdpath("data") ..  "/lazy/extensions/nvchad_types"] = true,
+          [vim.fn.stdpath("data") .. "/lazy/lazy.nvim/lua/lazy"] = true,
         },
         maxPreload = 100000,
         preloadFileSize = 10000,


### PR DESCRIPTION
To easen chore of maintaining plugin spec for `nvchad_types`, I'll use Lazy.nvim types instead.
But to do that, I'd need to add lazy.nvim to be part of the workspace libraries