### PR TITLE
Fix telescope and nvdash search icon, nvdash themes desc

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -60,11 +60,11 @@ M.ui = {
     },
 
     buttons = {
-      { "  Find File", "Spc f f", "Telescope find_files" },
+      { "  Find File", "Spc f f", "Telescope find_files" },
       { "  Recent Files", "Spc f o", "Telescope oldfiles" },
       { "  Find Word", "Spc f w", "Telescope live_grep" },
       { "  Bookmarks", "Spc b m", "Telescope marks" },
-      { "  Themes", "Spc t f", "Telescope themes" },
+      { "  Themes", "Spc t h", "Telescope themes" },
     },
   },
 

--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -10,7 +10,7 @@ local options = {
       "--column",
       "--smart-case",
     },
-    prompt_prefix = "   ",
+    prompt_prefix = "   ",
     selection_caret = "  ",
     entry_prefix = "  ",
     initial_mode = "insert",


### PR DESCRIPTION
nerd font default not view current config search icon
current search icon:   
chagned serach icon:    origin nerdfont icon name nf-seti-search

origin
<img width="444" alt="image" src="https://user-images.githubusercontent.com/45023042/222334446-fa39f151-7eca-4003-a79d-7f3e6d4a5c1b.png">
fixed  search icon and open telescope themes desc  <leader>th
<img width="410" alt="image" src="https://user-images.githubusercontent.com/45023042/222334724-d7409f53-2ead-4cda-9679-abb757ecbb64.png">

telescope prefix icon 
<img width="843" alt="image" src="https://user-images.githubusercontent.com/45023042/222334946-43eee993-69ca-4908-8a4c-9b3b36a316a7.png">

<img width="684" alt="image" src="https://user-images.githubusercontent.com/45023042/222334878-6e808e67-e2b4-4a10-9733-19cc82cfda57.png">
