### PR TITLE
Fix the "toggle theme" string in the default configs.

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -68,7 +68,7 @@ M.ui = {
       { "  Recent Files", "Spc f o", "Telescope oldfiles" },
       { "  Find Word", "Spc f w", "Telescope live_grep" },
       { "  Bookmarks", "Spc b m", "Telescope marks" },
-      { "  Themes", "Spc t f", "Telescope themes" },
+      { "  Themes", "Spc t h", "Telescope themes" },
       { "  Mappings", "Spc c h", "NvCheatsheet" },
     },
   },


### PR DESCRIPTION
The actual keybind is `<leader>t h` and not `<leader> t f `