### PR TITLE
fix: check if section mappings exist before using it

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -76,8 +76,11 @@ M.load_mappings = function(section, mapping_opt)
   local mappings = require("core.utils").load_config().mappings
 
   if type(section) == "string" then
-    mappings[section]["plugin"] = nil
-    mappings = { mappings[section] }
+    local section_mappings = mappings[section]
+    if section_mappings then
+      section_mappings["plugin"] = nil
+      mappings = { section_mappings }
+    end
   end
 
   for _, sect in pairs(mappings) do


### PR DESCRIPTION
I get this error on a fresh install:
```
  Error detected while processing /home/amir/.config/nvim/init.lua:
  E5113: Error while calling lua chunk: /home/amir/.config/nvim/lua/core/utils.lua:79: attempt to index a nil value
  stack traceback:
          /home/amir/.config/nvim/lua/core/utils.lua:79: in function 'load_mappings'
          /home/amir/.config/nvim/lua/plugins/init.lua:29: in main chunk
          [C]: in function 'require'
```
This should fix it