### PR TITLE
fix: fix branch for base46 plugin

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -14,7 +14,7 @@ local plugins = {
   ["NvChad/extensions"] = { branch = "main", module = { "telescope", "nvchad" } },
 
   ["NvChad/base46"] = {
-    branch = "main",
+    branch = "master",
     config = function()
       local ok, base46 = pcall(require, "base46")
 


### PR DESCRIPTION
The base46 doesn't use the main branch for v1, but master.