### PR TITLE
fix(mappings): tab expanding snippets

### DIFF
--- a/lua/nvchad/configs/cmp.lua
+++ b/lua/nvchad/configs/cmp.lua
@@ -27,8 +27,8 @@ local options = {
     ["<Tab>"] = cmp.mapping(function(fallback)
       if cmp.visible() then
         cmp.select_next_item()
-      elseif require("luasnip").expand_or_jumpable() then
-        require("luasnip").expand_or_jump()
+      elseif require("luasnip").locally_jumpable(1) then
+        require("luasnip").jump(1)
       else
         fallback()
       end


### PR DESCRIPTION
when entering insert mode on top of a snippet name, pressing <Tab> would cause the snippet to expand, without any visual queues about this behaviour. changed to reflect recommended config from nvim-cmp: https://github.com/hrsh7th/nvim-cmp/wiki/Example-mappings#luasnip


### Example

When insert mode is entered on something which is identical to a LuaSnippet trigger, like `--`, for the snippet `region~` in Lua, pressing `<Tab>` expands the snippet.

In the example below insert mode was entered with `a` on a lua file containing `--`, which results in the cursor at the position of the `+`

```lua
--+
```

As no cmp menu is shown when entering insert mode, the result of pressing `<Tab>` is:

```lua
--#region
```

However the expected result would be:

```lua
--<Tab>
```

With `<Tab>` as the chars configured to be placed when pressing the tab key.
This is precisely what my changes accomplish.